### PR TITLE
[feat][#34] projectboardview

### DIFF
--- a/gridy.xcodeproj/project.pbxproj
+++ b/gridy.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		AD8ECB922ABC7CA20040A0B8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AD8ECB912ABC7CA20040A0B8 /* Assets.xcassets */; };
 		AD96ED3C2AD1183A005D197B /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD96ED3B2AD1183A005D197B /* Project.swift */; };
 		AD96ED3E2AD13AE4005D197B /* ProjectBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD96ED3D2AD13AE4005D197B /* ProjectBoardView.swift */; };
-		AD96ED402AD1BC17005D197B /* ProjectItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD96ED3F2AD1BC17005D197B /* ProjectItemView.swift */; };
+		AD96ED402AD1BC17005D197B /* ProjectCreationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD96ED3F2AD1BC17005D197B /* ProjectCreationView.swift */; };
 		AD96ED422AD1BCAD005D197B /* ProjectItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD96ED412AD1BCAD005D197B /* ProjectItem.swift */; };
 		AD96ED442AD30312005D197B /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD96ED432AD30312005D197B /* APIError.swift */; };
 		AD96ED622AD5B005005D197B /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD96ED612AD5B005005D197B /* BackgroundView.swift */; };
@@ -54,6 +54,7 @@
 		ADACF5FF2AC25760008AADFA /* PlanItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADACF5FE2AC25760008AADFA /* PlanItem.swift */; };
 		ADACF60A2AC26CDF008AADFA /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADACF6092AC26CDF008AADFA /* Color+Extension.swift */; };
 		D1115A102ACEE73A00DBE5D4 /* LineAreaRoyceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1115A0F2ACEE73A00DBE5D4 /* LineAreaRoyceView.swift */; };
+		EE2EF6AA2ADE6626007B94DF /* ProjectItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2EF6A92ADE6626007B94DF /* ProjectItemView.swift */; };
 		EE4ADF5A2AD7CD8900D99AEA /* ProjectBoardSideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4ADF592AD7CD8900D99AEA /* ProjectBoardSideView.swift */; };
 		EE4ADF5C2AD7CD9500D99AEA /* ProjectBoardMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4ADF5B2AD7CD9500D99AEA /* ProjectBoardMainView.swift */; };
 		EE909A412AC3CDC700C9AAF0 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE909A402AC3CDC700C9AAF0 /* Utils.swift */; };
@@ -106,7 +107,7 @@
 		AD8ECB962ABC7CA20040A0B8 /* gridy.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = gridy.entitlements; sourceTree = "<group>"; };
 		AD96ED3B2AD1183A005D197B /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
 		AD96ED3D2AD13AE4005D197B /* ProjectBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectBoardView.swift; sourceTree = "<group>"; };
-		AD96ED3F2AD1BC17005D197B /* ProjectItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectItemView.swift; sourceTree = "<group>"; };
+		AD96ED3F2AD1BC17005D197B /* ProjectCreationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreationView.swift; sourceTree = "<group>"; };
 		AD96ED412AD1BCAD005D197B /* ProjectItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectItem.swift; sourceTree = "<group>"; };
 		AD96ED432AD30312005D197B /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		AD96ED612AD5B005005D197B /* BackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundView.swift; sourceTree = "<group>"; };
@@ -116,6 +117,7 @@
 		ADACF5FE2AC25760008AADFA /* PlanItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanItem.swift; sourceTree = "<group>"; };
 		ADACF6092AC26CDF008AADFA /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		D1115A0F2ACEE73A00DBE5D4 /* LineAreaRoyceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineAreaRoyceView.swift; sourceTree = "<group>"; };
+		EE2EF6A92ADE6626007B94DF /* ProjectItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectItemView.swift; sourceTree = "<group>"; };
 		EE4ADF592AD7CD8900D99AEA /* ProjectBoardSideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectBoardSideView.swift; sourceTree = "<group>"; };
 		EE4ADF5B2AD7CD9500D99AEA /* ProjectBoardMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectBoardMainView.swift; sourceTree = "<group>"; };
 		EE909A402AC3CDC700C9AAF0 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -252,7 +254,8 @@
 				ADA3E9CD2AD0790600303958 /* ProjectBoard.swift */,
 				AD96ED3D2AD13AE4005D197B /* ProjectBoardView.swift */,
 				AD96ED412AD1BCAD005D197B /* ProjectItem.swift */,
-				AD96ED3F2AD1BC17005D197B /* ProjectItemView.swift */,
+				EE2EF6A92ADE6626007B94DF /* ProjectItemView.swift */,
+				AD96ED3F2AD1BC17005D197B /* ProjectCreationView.swift */,
 				EE4ADF592AD7CD8900D99AEA /* ProjectBoardSideView.swift */,
 				EE4ADF5B2AD7CD9500D99AEA /* ProjectBoardMainView.swift */,
 			);
@@ -584,8 +587,9 @@
 				EEBDE40E2AD3F29A00B52C98 /* RightSmallTaskElementView.swift in Sources */,
 				AD96ED422AD1BCAD005D197B /* ProjectItem.swift in Sources */,
 				EE909A602AC3CFAF00C9AAF0 /* TimeAxisAreaView.swift in Sources */,
-				AD96ED402AD1BC17005D197B /* ProjectItemView.swift in Sources */,
+				AD96ED402AD1BC17005D197B /* ProjectCreationView.swift in Sources */,
 				EE909A622AC3CFB800C9AAF0 /* ScheduleAreaView.swift in Sources */,
+				EE2EF6AA2ADE6626007B94DF /* ProjectItemView.swift in Sources */,
 				975A620D2ACE946A00DE31AB /* Date+Extension.swift in Sources */,
 				EE909A662AC3D10300C9AAF0 /* LeftToolBarAreaView.swift in Sources */,
 				AD96ED622AD5B005005D197B /* BackgroundView.swift in Sources */,

--- a/gridy.xcodeproj/project.pbxproj
+++ b/gridy.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		ADACF5FF2AC25760008AADFA /* PlanItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADACF5FE2AC25760008AADFA /* PlanItem.swift */; };
 		ADACF60A2AC26CDF008AADFA /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADACF6092AC26CDF008AADFA /* Color+Extension.swift */; };
 		D1115A102ACEE73A00DBE5D4 /* LineAreaRoyceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1115A0F2ACEE73A00DBE5D4 /* LineAreaRoyceView.swift */; };
+		EE4ADF5A2AD7CD8900D99AEA /* ProjectBoardSideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4ADF592AD7CD8900D99AEA /* ProjectBoardSideView.swift */; };
+		EE4ADF5C2AD7CD9500D99AEA /* ProjectBoardMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4ADF5B2AD7CD9500D99AEA /* ProjectBoardMainView.swift */; };
 		EE909A412AC3CDC700C9AAF0 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE909A402AC3CDC700C9AAF0 /* Utils.swift */; };
 		EE909A472AC3CE3C00C9AAF0 /* CalendarLayoutTemp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE909A462AC3CE3C00C9AAF0 /* CalendarLayoutTemp.swift */; };
 		EE909A492AC3CE4500C9AAF0 /* ThinkingLayoutTemp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE909A482AC3CE4500C9AAF0 /* ThinkingLayoutTemp.swift */; };
@@ -111,6 +113,8 @@
 		ADACF5FE2AC25760008AADFA /* PlanItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanItem.swift; sourceTree = "<group>"; };
 		ADACF6092AC26CDF008AADFA /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		D1115A0F2ACEE73A00DBE5D4 /* LineAreaRoyceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineAreaRoyceView.swift; sourceTree = "<group>"; };
+		EE4ADF592AD7CD8900D99AEA /* ProjectBoardSideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectBoardSideView.swift; sourceTree = "<group>"; };
+		EE4ADF5B2AD7CD9500D99AEA /* ProjectBoardMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectBoardMainView.swift; sourceTree = "<group>"; };
 		EE909A402AC3CDC700C9AAF0 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		EE909A462AC3CE3C00C9AAF0 /* CalendarLayoutTemp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarLayoutTemp.swift; sourceTree = "<group>"; };
 		EE909A482AC3CE4500C9AAF0 /* ThinkingLayoutTemp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingLayoutTemp.swift; sourceTree = "<group>"; };
@@ -189,7 +193,6 @@
 			children = (
 				AD8ECB8C2ABC7CA10040A0B8 /* gridy */,
 				AD8ECB8B2ABC7CA10040A0B8 /* Products */,
-				AD96ED682AD6EDB1005D197B /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -244,6 +247,8 @@
 				AD96ED3D2AD13AE4005D197B /* ProjectBoardView.swift */,
 				AD96ED412AD1BCAD005D197B /* ProjectItem.swift */,
 				AD96ED3F2AD1BC17005D197B /* ProjectItemView.swift */,
+				EE4ADF592AD7CD8900D99AEA /* ProjectBoardSideView.swift */,
+				EE4ADF5B2AD7CD9500D99AEA /* ProjectBoardMainView.swift */,
 			);
 			path = ProjectBoard;
 			sourceTree = "<group>";
@@ -574,11 +579,13 @@
 				EE909A662AC3D10300C9AAF0 /* LeftToolBarAreaView.swift in Sources */,
 				AD96ED622AD5B005005D197B /* BackgroundView.swift in Sources */,
 				975A620B2ACE939900DE31AB /* DateInfo.swift in Sources */,
+				EE4ADF5C2AD7CD9500D99AEA /* ProjectBoardMainView.swift in Sources */,
 				EEA539812AC400400000383F /* TimelineLayoutContentView.swift in Sources */,
 				AD96ED442AD30312005D197B /* APIError.swift in Sources */,
 				EE909A492AC3CE4500C9AAF0 /* ThinkingLayoutTemp.swift in Sources */,
 				97BD1B672AD14F8C000F00FA /* ScrollDatePickerView.swift in Sources */,
 				AD01D50C2ACC7B5E00474E7A /* String+Extension.swift in Sources */,
+				EE4ADF5A2AD7CD8900D99AEA /* ProjectBoardSideView.swift in Sources */,
 				AD8ECB8E2ABC7CA10040A0B8 /* GridyApp.swift in Sources */,
 				EE909A5E2AC3CFA600C9AAF0 /* LineIndexAreaView.swift in Sources */,
 				975A62132ACE970800DE31AB /* DayGridView.swift in Sources */,

--- a/gridy/Sources/Extensions/Date+Extension.swift
+++ b/gridy/Sources/Extensions/Date+Extension.swift
@@ -25,8 +25,13 @@ extension Date {
 //        Date.dateFormatter.locale = Locale(identifier: "ko_KR")
         return Date.dateFormatter.string(from: self)
     }
+    
+    var formattedDate: String {
+        Date.dateFormatter.dateFormat = "yyyy.MM.dd"
+        return Date.dateFormatter.string(from: self)
+    }
 
-    var formattedDate: Date {
+    var filteredDate: Date {
         Calendar.current.startOfDay(for: self)
     }
     

--- a/gridy/Sources/Network/APIService.swift
+++ b/gridy/Sources/Network/APIService.swift
@@ -12,13 +12,13 @@ import FirebaseFirestoreSwift
 
 /// Service CRUD
 struct APIService {
-    var create: () async throws -> Void
+    var create: (String) async throws -> Void
     var readAllProjects: () async throws -> [Project]
     var updateProjectTitle: @Sendable (_ id: String, _ newTitle: String) async throws -> Void
     var delete: @Sendable (_ id: String) async throws -> Void
     
     init(
-        create: @escaping () async throws -> Void,
+        create: @escaping (String) async throws -> Void,
         readAllProjects: @escaping () async throws -> [Project],
         updateProjectTitle: @escaping @Sendable (String, String) async throws -> Void,
         delete: @escaping @Sendable (String) async throws -> Void
@@ -48,10 +48,10 @@ extension APIService {
     }
     
     static let liveValue = Self(
-        create: {
+        create: { title in
             let id = try basePath.document().documentID
             let data = ["id": id,
-                        "title": "제목 없음",
+                        "title": title,
                         "ownerUid": try uid,
                         "createdDate": Date(),
                         "lastModifiedDate": Date()] as [String: Any]
@@ -78,14 +78,14 @@ extension APIService {
 // MARK: - test, mock
 extension APIService {
     static let testValue = Self(
-        create: { },
+        create: { _ in },
         readAllProjects: {
             [Project.mock] },
         updateProjectTitle: { _, _ in },
         delete: { _ in }
     )
     static let mockValue = Self(
-        create: { },
+        create: { _ in },
         readAllProjects: {
             [Project.mock] },
         updateProjectTitle: { _, _ in },

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoard.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoard.swift
@@ -19,6 +19,8 @@ struct ProjectBoard: Reducer {
         var projects: IdentifiedArrayOf<ProjectItem.State> = []
         var successToFetchData = false
         var isInProgress = false
+        var isSheetPresented = false
+        @BindingState var title = ""
     }
     
     enum Action: BindableAction, Equatable {
@@ -28,11 +30,12 @@ struct ProjectBoard: Reducer {
         case fetchAllProjects
         case fetchAllProjectsResponse(TaskResult<[Project]?>)
         case setProcessing(Bool)
-        
+        case titleChanged(String)
         case binding(BindingAction<State>)
+        case setSheet(isPresented: Bool)
         case deleteProjectButtonTapped(id: ProjectItem.State.ID, action: ProjectItem.Action)
     }
-     
+    
     var body: some Reducer<State, Action> {
         BindingReducer()
         Reduce { state, action in
@@ -43,9 +46,10 @@ struct ProjectBoard: Reducer {
                 }
                 
             case .createNewProjectButtonTapped:
+                let title = state.title
                 return .run { send in
-                    try await apiService.create()
-                    await send(.fetchAllProjects)
+                    try await apiService.create(title)
+                    await send(.setSheet(isPresented: false))
                 }
                 
             case .readAllButtonTapped:
@@ -83,6 +87,15 @@ struct ProjectBoard: Reducer {
                 state.isInProgress = isInProgress
                 return .none
                 
+            case let .setSheet(isPresented: isPresented):
+                state.title = ""
+                state.isSheetPresented = isPresented
+                return .none
+                
+            case let .titleChanged(changedTitle):
+                state.title = changedTitle
+                return .none
+                
             case .binding:
                 return .none
                 
@@ -101,4 +114,3 @@ struct ProjectBoard: Reducer {
         }
     }
 }
-

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoard.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoard.swift
@@ -49,6 +49,7 @@ struct ProjectBoard: Reducer {
                 let title = state.title
                 return .run { send in
                     try await apiService.create(title)
+                    await send(.fetchAllProjects)
                     await send(.setSheet(isPresented: false))
                 }
                 

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -8,33 +8,178 @@
 import SwiftUI
 
 struct ProjectBoardMainView: View {
+    let columnsFolders = [GridItem(.adaptive(minimum: 274), spacing: 20)]
+    let columnsProjects = [GridItem(.adaptive(minimum: 274), spacing: 20)]
+    
     var body: some View {
         GeometryReader { proxy in
-            VStack(alignment: .leading, spacing: 0) {
-                // RightTopBarArea
-                Rectangle()
-                    .foregroundStyle(.white)
-                    .frame(width: proxy.size.width)
-                    .frame(height: 36)
-                HStack(alignment: .center, spacing: 0) {
-                    Text("Directory")
-                        .font(.custom("Pretendard-Bold", size: 32))
-                    Spacer()
-                    Button {
-                        // Create a new project
-                    } label: {
-                        RoundedRectangle(cornerRadius: 12)
-                            .frame(width: 119, height: 35)
-                            .foregroundStyle(.blue)
-                            .overlay {
-                                Text("New Project")
-                                    .foregroundStyle(.white)
-                                    .font(.custom("Pretendard-SemiBold", size: 14))
-                            }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    // RightTopBarArea
+                    Rectangle()
+                        .foregroundStyle(.gray.opacity(0.1))
+                        .frame(height: 36)
+                    
+                    HStack(alignment: .center, spacing: 0) {
+                        Text("Directory")
+                            .font(.custom("Pretendard-Bold", size: 32))
+                            .padding(.vertical, 16)
+                        Spacer()
+                        Button {
+                            // Create a new project
+                        } label: {
+                            RoundedRectangle(cornerRadius: 12)
+                                .frame(width: 119, height: 35)
+                                .foregroundStyle(.blue)
+                                .overlay {
+                                    Text("New Project")
+                                        .foregroundStyle(.white)
+                                        .font(.custom("Pretendard-SemiBold", size: 14))
+                                }
+                        }
+                        .buttonStyle(PlainButtonStyle())
                     }
-                    .buttonStyle(PlainButtonStyle())
+                    .padding(.horizontal, 20)
+                    .padding(.top, 16)
+                    
+                    VStack(alignment: .leading, spacing: 16) {
+                        RoundedRectangle(cornerRadius: 12)
+                            .frame(width: 70, height: 20)
+                            .foregroundStyle(.gray.opacity(0.2))
+                            .overlay(
+                                Text("Folders")
+                                    .font(.custom("Pretendard-Bold", size: 12))
+                            )
+                        LazyVGrid(columns: columnsFolders, alignment: .leading, spacing: 20) {
+                            ForEach(1...8, id: \.self) { _ in
+                                RoundedRectangle(cornerRadius: 6)
+                                    .frame(height: 65)
+                                    .foregroundStyle(.white)
+                                    .overlay {
+                                        HStack(alignment: .top, spacing: 0) {
+                                            VStack(alignment: .leading, spacing: 0) {
+                                                Text("Folder Name")
+                                                    .font(.custom("Pretendard-Bold", size: 16))
+                                                    .multilineTextAlignment(.leading)
+                                                    .padding(.bottom, 6)
+                                                Text("4 Projects")
+                                                    .foregroundStyle(.gray)
+                                                    .multilineTextAlignment(.leading)
+                                                    .font(.custom("Pretendard-Medium", size: 14))
+                                            }
+                                            .padding(.top, 12)
+                                            .padding(.bottom, 11)
+                                            .padding(.leading, 12)
+                                            Spacer()
+                                            Button {
+                                                // 더보기 버튼
+                                            } label: {
+                                                RoundedRectangle(cornerRadius: 6)
+                                                    .frame(width: 20, height: 20)
+                                                    .foregroundStyle(.gray.opacity(0.1))
+                                                    .overlay {
+                                                        Image(systemName: "ellipsis")
+                                                            .foregroundStyle(.gray)
+                                                    }
+                                            }
+                                            .buttonStyle(PlainButtonStyle())
+                                            .padding(.top, 4)
+                                            .padding(.trailing, 4)
+                                        }
+                                    }
+                            }
+                        }
+                    }
+                    .padding(.top, 6)
+                    .padding(.horizontal, 24)
+                    
+                    VStack(alignment: .leading, spacing: 16) {
+                        RoundedRectangle(cornerRadius: 12)
+                            .frame(width: 70, height: 20)
+                            .foregroundStyle(.gray.opacity(0.2))
+                            .overlay(
+                                Text("Projects")
+                                    .font(.custom("Pretendard-Bold", size: 12))
+                            )
+                        LazyVGrid(columns: columnsProjects, alignment: .leading, spacing: 20) {
+                            ForEach(1...15, id: \.self) { _ in
+                                RoundedRectangle(cornerRadius: 6)
+                                    .frame(height: 108)
+                                    .foregroundStyle(.white)
+                                    .overlay {
+                                        VStack(alignment: .leading, spacing: 0) {
+                                            HStack(alignment: .center, spacing: 0) {
+                                                Text("Last updated on")
+                                                    .font(.custom("Pretendard-Regular", size: 12))
+                                                    .foregroundStyle(.gray)
+                                                    .padding(.leading, 10)
+                                                    .padding(.trailing, 4)
+                                                Text("2023.10.17")
+                                                    .font(.custom("Pretendard-Bold", size: 12))
+                                                    .foregroundStyle(.gray)
+                                                    .multilineTextAlignment(.leading)
+                                                Spacer()
+                                                Button {
+                                                    // 더보기 버튼
+                                                } label: {
+                                                    RoundedRectangle(cornerRadius: 6)
+                                                        .frame(width: 20, height: 20)
+                                                        .foregroundStyle(.gray.opacity(0.1))
+                                                        .overlay {
+                                                            Image(systemName: "ellipsis")
+                                                                .foregroundStyle(.gray)
+                                                        }
+                                                }
+                                                .buttonStyle(PlainButtonStyle())
+                                                .padding(.vertical, 4)
+                                                .padding(.trailing, 4)
+                                            }
+                                            .background(.gray.opacity(0.1))
+                                            .clipShape(
+                                                .rect(
+                                                    topLeadingRadius: 6,
+                                                    bottomLeadingRadius: 0,
+                                                    bottomTrailingRadius: 0,
+                                                    topTrailingRadius: 6,
+                                                    style: .continuous
+                                                )
+                                            )
+                                            .frame(height: 28)
+                                            Text("Project Name")
+                                                .font(.custom("Pretendard-Bold", size: 20))
+                                                .multilineTextAlignment(.leading)
+                                                .padding(.leading, 12)
+                                                .padding(.top, 12)
+                                                .padding(.bottom, 11)
+                                            HStack(alignment: .center, spacing: 0) {
+                                                Text("2023.10.01 ~ 2023.11.14")
+                                                    .font(.custom("Pretendard-SemiBold", size: 12))
+                                                    .multilineTextAlignment(.leading)
+                                                    .padding(.horizontal, 8)
+                                                    .frame(height: 24)
+                                                    .background(.gray.opacity(0.3))
+                                                    .cornerRadius(6)
+                                                    .padding(.trailing, 6)
+                                                Text("45 Days")
+                                                    .font(.custom("Pretendard-SemiBold", size: 12))
+                                                    .multilineTextAlignment(.leading)
+                                                    .padding(.horizontal, 8)
+                                                    .frame(height: 24)
+                                                    .background(.gray.opacity(0.3))
+                                                    .cornerRadius(6)
+                                            }
+                                            .padding(.leading, 12)
+                                            .padding(.bottom, 9)
+                                        }
+                                    }
+                            }
+                        }
+                    }
+                    
+                    .padding(.top, 64)
+                    .padding(.horizontal, 24)
                 }
-                .padding(20)
+                .frame(width: proxy.size.width)
             }
         }
     }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -12,6 +12,7 @@ struct ProjectBoardMainView: View {
     let columnsFolders = [GridItem(.adaptive(minimum: 274), spacing: 20)]
     let columnsProjects = [GridItem(.adaptive(minimum: 274), spacing: 20)]
     let store: StoreOf<ProjectBoard>
+    @State var tag: Int? = nil
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -112,6 +113,9 @@ struct ProjectBoardMainView: View {
                                     )
                                 ) {
                                     ProjectItemView(store: $0)
+                                        .onTapGesture {
+                                            self.tag = 2
+                                        }
                                 }
                             }
                         }
@@ -120,6 +124,9 @@ struct ProjectBoardMainView: View {
                         .padding(.horizontal, 24)
                     }
                     .frame(width: proxy.size.width)
+                    NavigationLink(destination: TimelineLayoutView(), tag: 2, selection: self.$tag) {
+                        EmptyView()
+                    }
                 }
                 .onAppear {
                     viewStore.send(

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -12,7 +12,6 @@ struct ProjectBoardMainView: View {
     let columnsFolders = [GridItem(.adaptive(minimum: 274), spacing: 20)]
     let columnsProjects = [GridItem(.adaptive(minimum: 274), spacing: 20)]
     let store: StoreOf<ProjectBoard>
-    @Binding var isCreateNewProjectSheet: Bool
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -41,7 +40,7 @@ struct ProjectBoardMainView: View {
                                             .font(.custom("Pretendard-SemiBold", size: 14))
                                     }
                             }
-                            .buttonStyle(PlainButtonStyle())
+                            .buttonStyle(.plain)
                         }
                         .padding(.horizontal, 20)
                         .padding(.top, 16)

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -6,118 +6,74 @@
 //
 
 import SwiftUI
+import ComposableArchitecture
 
 struct ProjectBoardMainView: View {
     let columnsFolders = [GridItem(.adaptive(minimum: 274), spacing: 20)]
     let columnsProjects = [GridItem(.adaptive(minimum: 274), spacing: 20)]
+    let store: StoreOf<ProjectBoard>
+    @Binding var isCreateNewProjectSheet: Bool
     
     var body: some View {
-        GeometryReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    // RightTopBarArea
-                    Rectangle()
-                        .foregroundStyle(.gray.opacity(0.1))
-                        .frame(height: 36)
-                    
-                    HStack(alignment: .center, spacing: 0) {
-                        Text("Directory")
-                            .font(.custom("Pretendard-Bold", size: 32))
-                            .padding(.vertical, 16)
-                        Spacer()
-                        Button {
-                            // Create a new project
-                        } label: {
-                            RoundedRectangle(cornerRadius: 12)
-                                .frame(width: 119, height: 35)
-                                .foregroundStyle(.blue)
-                                .overlay {
-                                    Text("New Project")
-                                        .foregroundStyle(.white)
-                                        .font(.custom("Pretendard-SemiBold", size: 14))
-                                }
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.top, 16)
-                    
-                    VStack(alignment: .leading, spacing: 16) {
-                        RoundedRectangle(cornerRadius: 12)
-                            .frame(width: 70, height: 20)
-                            .foregroundStyle(.gray.opacity(0.2))
-                            .overlay(
-                                Text("Folders")
-                                    .font(.custom("Pretendard-Bold", size: 12))
-                            )
-                        LazyVGrid(columns: columnsFolders, alignment: .leading, spacing: 20) {
-                            ForEach(1...8, id: \.self) { _ in
-                                RoundedRectangle(cornerRadius: 6)
-                                    .frame(height: 65)
-                                    .foregroundStyle(.white)
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            GeometryReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // RightTopBarArea
+                        Rectangle()
+                            .foregroundStyle(.gray.opacity(0.1))
+                            .frame(height: 36)
+                        
+                        HStack(alignment: .center, spacing: 0) {
+                            Text("Directory")
+                                .font(.custom("Pretendard-Bold", size: 32))
+                                .padding(.vertical, 16)
+                            Spacer()
+                            Button {
+                                viewStore.send(.setSheet(isPresented: true))
+                            } label: {
+                                RoundedRectangle(cornerRadius: 12)
+                                    .frame(width: 119, height: 35)
+                                    .foregroundStyle(.blue)
                                     .overlay {
-                                        HStack(alignment: .top, spacing: 0) {
-                                            VStack(alignment: .leading, spacing: 0) {
-                                                Text("Folder Name")
-                                                    .font(.custom("Pretendard-Bold", size: 16))
-                                                    .multilineTextAlignment(.leading)
-                                                    .padding(.bottom, 6)
-                                                Text("4 Projects")
-                                                    .foregroundStyle(.gray)
-                                                    .multilineTextAlignment(.leading)
-                                                    .font(.custom("Pretendard-Medium", size: 14))
-                                            }
-                                            .padding(.top, 12)
-                                            .padding(.bottom, 11)
-                                            .padding(.leading, 12)
-                                            Spacer()
-                                            Button {
-                                                // 더보기 버튼
-                                            } label: {
-                                                RoundedRectangle(cornerRadius: 6)
-                                                    .frame(width: 20, height: 20)
-                                                    .foregroundStyle(.gray.opacity(0.1))
-                                                    .overlay {
-                                                        Image(systemName: "ellipsis")
-                                                            .foregroundStyle(.gray)
-                                                    }
-                                            }
-                                            .buttonStyle(PlainButtonStyle())
-                                            .padding(.top, 4)
-                                            .padding(.trailing, 4)
-                                        }
+                                        Text("New Project")
+                                            .foregroundStyle(.white)
+                                            .font(.custom("Pretendard-SemiBold", size: 14))
                                     }
                             }
+                            .buttonStyle(PlainButtonStyle())
                         }
-                    }
-                    .padding(.top, 6)
-                    .padding(.horizontal, 24)
-                    
-                    VStack(alignment: .leading, spacing: 16) {
-                        RoundedRectangle(cornerRadius: 12)
-                            .frame(width: 70, height: 20)
-                            .foregroundStyle(.gray.opacity(0.2))
-                            .overlay(
-                                Text("Projects")
-                                    .font(.custom("Pretendard-Bold", size: 12))
-                            )
-                        LazyVGrid(columns: columnsProjects, alignment: .leading, spacing: 20) {
-                            ForEach(1...15, id: \.self) { _ in
-                                RoundedRectangle(cornerRadius: 6)
-                                    .frame(height: 108)
-                                    .foregroundStyle(.white)
-                                    .overlay {
-                                        VStack(alignment: .leading, spacing: 0) {
-                                            HStack(alignment: .center, spacing: 0) {
-                                                Text("Last updated on")
-                                                    .font(.custom("Pretendard-Regular", size: 12))
-                                                    .foregroundStyle(.gray)
-                                                    .padding(.leading, 10)
-                                                    .padding(.trailing, 4)
-                                                Text("2023.10.17")
-                                                    .font(.custom("Pretendard-Bold", size: 12))
-                                                    .foregroundStyle(.gray)
-                                                    .multilineTextAlignment(.leading)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 16)
+                        
+                        VStack(alignment: .leading, spacing: 16) {
+                            RoundedRectangle(cornerRadius: 12)
+                                .frame(width: 70, height: 20)
+                                .foregroundStyle(.gray.opacity(0.2))
+                                .overlay(
+                                    Text("Folders")
+                                        .font(.custom("Pretendard-Bold", size: 12))
+                                )
+                            LazyVGrid(columns: columnsFolders, alignment: .leading, spacing: 20) {
+                                ForEach(1...8, id: \.self) { _ in
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .frame(height: 65)
+                                        .foregroundStyle(.white)
+                                        .overlay {
+                                            HStack(alignment: .top, spacing: 0) {
+                                                VStack(alignment: .leading, spacing: 0) {
+                                                    Text("Folder Name")
+                                                        .font(.custom("Pretendard-Bold", size: 16))
+                                                        .multilineTextAlignment(.leading)
+                                                        .padding(.bottom, 6)
+                                                    Text("4 Projects")
+                                                        .foregroundStyle(.gray)
+                                                        .multilineTextAlignment(.leading)
+                                                        .font(.custom("Pretendard-Medium", size: 14))
+                                                }
+                                                .padding(.top, 12)
+                                                .padding(.bottom, 11)
+                                                .padding(.leading, 12)
                                                 Spacer()
                                                 Button {
                                                     // 더보기 버튼
@@ -131,60 +87,42 @@ struct ProjectBoardMainView: View {
                                                         }
                                                 }
                                                 .buttonStyle(PlainButtonStyle())
-                                                .padding(.vertical, 4)
+                                                .padding(.top, 4)
                                                 .padding(.trailing, 4)
                                             }
-                                            .background(.gray.opacity(0.1))
-                                            .clipShape(
-                                                .rect(
-                                                    topLeadingRadius: 6,
-                                                    bottomLeadingRadius: 0,
-                                                    bottomTrailingRadius: 0,
-                                                    topTrailingRadius: 6,
-                                                    style: .continuous
-                                                )
-                                            )
-                                            .frame(height: 28)
-                                            Text("Project Name")
-                                                .font(.custom("Pretendard-Bold", size: 20))
-                                                .multilineTextAlignment(.leading)
-                                                .padding(.leading, 12)
-                                                .padding(.top, 12)
-                                                .padding(.bottom, 11)
-                                            HStack(alignment: .center, spacing: 0) {
-                                                Text("2023.10.01 ~ 2023.11.14")
-                                                    .font(.custom("Pretendard-SemiBold", size: 12))
-                                                    .multilineTextAlignment(.leading)
-                                                    .padding(.horizontal, 8)
-                                                    .frame(height: 24)
-                                                    .background(.gray.opacity(0.3))
-                                                    .cornerRadius(6)
-                                                    .padding(.trailing, 6)
-                                                Text("45 Days")
-                                                    .font(.custom("Pretendard-SemiBold", size: 12))
-                                                    .multilineTextAlignment(.leading)
-                                                    .padding(.horizontal, 8)
-                                                    .frame(height: 24)
-                                                    .background(.gray.opacity(0.3))
-                                                    .cornerRadius(6)
-                                            }
-                                            .padding(.leading, 12)
-                                            .padding(.bottom, 9)
                                         }
-                                    }
+                                }
                             }
                         }
+                        .padding(.top, 6)
+                        .padding(.horizontal, 24)
+                        
+                        VStack(alignment: .leading, spacing: 16) {
+                            RoundedRectangle(cornerRadius: 12)
+                                .frame(width: 70, height: 20)
+                                .foregroundStyle(.gray.opacity(0.2))
+                                .overlay(
+                                    Text("Projects")
+                                        .font(.custom("Pretendard-Bold", size: 12))
+                                )
+                            LazyVGrid(columns: columnsProjects, alignment: .leading, spacing: 20) {
+                                ForEach(0..<15) { _ in
+                                    ProjectItemView(
+                                        store: Store(
+                                            initialState: ProjectItem.State(),
+                                            reducer: { ProjectItem() }
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                        
+                        .padding(.top, 64)
+                        .padding(.horizontal, 24)
                     }
-                    
-                    .padding(.top, 64)
-                    .padding(.horizontal, 24)
+                    .frame(width: proxy.size.width)
                 }
-                .frame(width: proxy.size.width)
             }
         }
     }
-}
-
-#Preview {
-    ProjectBoardMainView()
 }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -54,7 +54,7 @@ struct ProjectBoardMainView: View {
                                         .font(.custom("Pretendard-Bold", size: 12))
                                 )
                             LazyVGrid(columns: columnsFolders, alignment: .leading, spacing: 20) {
-                                ForEach(1...8, id: \.self) { _ in
+                                ForEach(1...2, id: \.self) { _ in
                                     RoundedRectangle(cornerRadius: 6)
                                         .frame(height: 65)
                                         .foregroundStyle(.white)

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -18,8 +18,13 @@ struct ProjectBoardMainView: View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             GeometryReader { proxy in
                 ScrollView {
+                    //TODO: NavigationLink 방식은 Store 이용하기
+                    NavigationLink(destination: TimelineLayoutView(), tag: 2, selection: self.$tag) {
+                        EmptyView()
+                    }
+                    .disabled(true)
                     VStack(alignment: .leading, spacing: 0) {
-                        // RightTopBarArea
+                        
                         Rectangle()
                             .foregroundStyle(.gray.opacity(0.1))
                             .frame(height: 36)
@@ -76,7 +81,7 @@ struct ProjectBoardMainView: View {
                                                 .padding(.leading, 12)
                                                 Spacer()
                                                 Button {
-                                                    // 더보기 버튼
+                                                    //TODO: 더보기 버튼
                                                 } label: {
                                                     RoundedRectangle(cornerRadius: 6)
                                                         .frame(width: 20, height: 20)
@@ -124,9 +129,6 @@ struct ProjectBoardMainView: View {
                         .padding(.horizontal, 24)
                     }
                     .frame(width: proxy.size.width)
-                    NavigationLink(destination: TimelineLayoutView(), tag: 2, selection: self.$tag) {
-                        EmptyView()
-                    }
                 }
                 .onAppear {
                     viewStore.send(

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -105,13 +105,13 @@ struct ProjectBoardMainView: View {
                                         .font(.custom("Pretendard-Bold", size: 12))
                                 )
                             LazyVGrid(columns: columnsProjects, alignment: .leading, spacing: 20) {
-                                ForEach(0..<15) { _ in
-                                    ProjectItemView(
-                                        store: Store(
-                                            initialState: ProjectItem.State(),
-                                            reducer: { ProjectItem() }
-                                        )
+                                ForEachStore(
+                                    store.scope(
+                                        state: \.projects,
+                                        action: { .deleteProjectButtonTapped(id: $0, action: $1) }
                                     )
+                                ) {
+                                    ProjectItemView(store: $0)
                                 }
                             }
                         }
@@ -120,6 +120,11 @@ struct ProjectBoardMainView: View {
                         .padding(.horizontal, 24)
                     }
                     .frame(width: proxy.size.width)
+                }
+                .onAppear {
+                    viewStore.send(
+                        .onAppear
+                    )
                 }
             }
         }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardMainView.swift
@@ -1,0 +1,45 @@
+//
+//  ProjectBoardMainView.swift
+//  gridy
+//
+//  Created by xnoag on 10/12/23.
+//
+
+import SwiftUI
+
+struct ProjectBoardMainView: View {
+    var body: some View {
+        GeometryReader { proxy in
+            VStack(alignment: .leading, spacing: 0) {
+                // RightTopBarArea
+                Rectangle()
+                    .foregroundStyle(.white)
+                    .frame(width: proxy.size.width)
+                    .frame(height: 36)
+                HStack(alignment: .center, spacing: 0) {
+                    Text("Directory")
+                        .font(.custom("Pretendard-Bold", size: 32))
+                    Spacer()
+                    Button {
+                        // Create a new project
+                    } label: {
+                        RoundedRectangle(cornerRadius: 12)
+                            .frame(width: 119, height: 35)
+                            .foregroundStyle(.blue)
+                            .overlay {
+                                Text("New Project")
+                                    .foregroundStyle(.white)
+                                    .font(.custom("Pretendard-SemiBold", size: 14))
+                            }
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+                .padding(20)
+            }
+        }
+    }
+}
+
+#Preview {
+    ProjectBoardMainView()
+}

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardSideView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardSideView.swift
@@ -1,0 +1,103 @@
+//
+//  ProjectBoardSideView.swift
+//  gridy
+//
+//  Created by xnoag on 10/12/23.
+//
+
+import SwiftUI
+
+struct ProjectBoardSideView: View {
+    @State var projectSearchText = ""
+    
+    var body: some View {
+        GeometryReader { proxy in
+            VStack(alignment: .leading, spacing: 0) {
+                // LeftTopBarArea
+                HStack(alignment: .center, spacing: 0) {
+                    Circle()
+                        .foregroundStyle(.gray)
+                        .frame(width: 24, height: 24)
+                        .padding(6)
+                    Text("UserName")
+                        .font(.custom("Pretendard-SemiBold", size: 14))
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+                }
+                .frame(height: 36)
+                // ProjectSearchArea
+                Rectangle()
+                    .frame(height: 52)
+                    .foregroundStyle(.white)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .foregroundStyle(.gray.opacity(0.1))
+                            .frame(width: 282, height: 36)
+                            .overlay {
+                                TextField("Search..", text: $projectSearchText)
+                                    .textFieldStyle(.plain)
+                                    .font(.custom("Pretendard-Regular", size: 14))
+                                    .padding(.leading, 12)
+                            }
+                    }
+                // ProjectMenuArea
+                VStack(alignment: .center, spacing: 0) {
+                    Button {
+                        print("New Folder")
+                    } label: {
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(.blue)
+                            .frame(width: 282, height: 40)
+                            .padding(.vertical, 16)
+                            .overlay {
+                                Text("New Folder")
+                                    .foregroundStyle(.white)
+                                    .font(.custom("Pretendard-Medium", size: 16))
+                            }
+                    }
+                    HStack(alignment: .top, spacing: 0) {
+                        Spacer()
+                        Button {
+                            print("Button/1")
+                        } label: {
+                            RoundedRectangle(cornerRadius: 6)
+                                .foregroundStyle(.black.opacity(0.7))
+                                .frame(width: 24, height: 24)
+                                .padding(.vertical, 4)
+                        }
+                        Button {
+                            print("Button/2")
+                        } label: {
+                            RoundedRectangle(cornerRadius: 6)
+                                .foregroundStyle(.black.opacity(0.7))
+                                .frame(width: 24, height: 24)
+                                .padding(.vertical, 4)
+                                .padding(.trailing, 4)
+                                .padding(.leading, 6)
+                        }
+                    }
+                    .background(Color.gray.opacity(0.5))
+                    HStack(spacing: 0) {
+                        Text("Directory")
+                            .font(.custom("Pretendard-Bold", size: 18))
+                            .padding(.top, 17)
+                            .padding(.bottom, 10)
+                            .padding(.leading, 16)
+                        Spacer()
+                    }
+                    List {
+                        
+                    }
+                    .frame(height: proxy.size.height)
+                }
+                .background(.white)
+                .buttonStyle(PlainButtonStyle())
+            }
+            .frame(width: 306)
+        }
+    }
+}
+
+#Preview {
+    ProjectBoardSideView()
+}

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardSideView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardSideView.swift
@@ -13,7 +13,6 @@ struct ProjectBoardSideView: View {
     var body: some View {
         GeometryReader { proxy in
             VStack(alignment: .leading, spacing: 0) {
-                // LeftTopBarArea
                 HStack(alignment: .center, spacing: 0) {
                     Circle()
                         .foregroundStyle(.gray)
@@ -25,7 +24,7 @@ struct ProjectBoardSideView: View {
                     Spacer()
                 }
                 .frame(height: 36)
-                // ProjectSearchArea
+                
                 Rectangle()
                     .frame(height: 52)
                     .foregroundStyle(.white)
@@ -40,7 +39,7 @@ struct ProjectBoardSideView: View {
                                     .padding(.leading, 12)
                             }
                     }
-                // ProjectMenuArea
+                
                 VStack(alignment: .center, spacing: 0) {
                     Button {
                         print("New Folder")
@@ -86,7 +85,7 @@ struct ProjectBoardSideView: View {
                         Spacer()
                     }
                     List {
-                        
+                        //TODO: Project Name List
                     }
                     .frame(height: proxy.size.height)
                 }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
@@ -9,21 +9,28 @@ import SwiftUI
 import ComposableArchitecture
 
 struct ProjectBoardView: View {
-    @State var isCreateNewProjectSheet = false
     let store: StoreOf<ProjectBoard>
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
-                HStack(spacing: 0) {
-                    ProjectBoardSideView()
-                        .frame(width: 306)
-                    ProjectBoardMainView(store: store, isCreateNewProjectSheet: $isCreateNewProjectSheet)
+            GeometryReader { geometry in
+                ZStack {
+                    HStack(spacing: 0) {
+                        ProjectBoardSideView()
+                            .frame(width: 306)
+                        ProjectBoardMainView(store: store)
+                    }
+                    if viewStore.isSheetPresented {
+                        ZStack {
+                            Color.black.opacity(0.5)
+                                .frame(width: geometry.size.width, height: geometry.size.height)
+                                .onTapGesture {
+                                    viewStore.send(ProjectBoard.Action.setSheet(isPresented: false))
+                                }
+                            ProjectCreationView(store: store)
+                        }
+                    }
                 }
-            .sheet(isPresented: viewStore.binding(
-                get: \.isSheetPresented,
-                send: ProjectBoard.Action.setSheet(isPresented:)
-            )) {
-                ProjectCreationView(store: store)
             }
         }
     }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
@@ -29,9 +29,6 @@ struct ProjectBoardView: View {
                                 }
                             ProjectCreationView(store: store)
                                 .offset(y: viewStore.isSheetPresented ? 0 : -50)
-                                .onExitCommand {
-                                    viewStore.send(ProjectBoard.Action.setSheet(isPresented: false))
-                                }
                         }
                     }
                 }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
@@ -9,41 +9,21 @@ import SwiftUI
 import ComposableArchitecture
 
 struct ProjectBoardView: View {
-    
+    @State var isCreateNewProjectSheet = false
     let store: StoreOf<ProjectBoard>
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
-            ZStack {
-                BackgroundView()
-                if viewStore.successToFetchData {
-                    VStack {
-                        Button("create new project") {
-                            viewStore.send(.createNewProjectButtonTapped)
-                        }
-                        Button("read all projects") {
-                            viewStore.send(.readAllButtonTapped)
-                        }
-                        ForEachStore(
-                            store.scope(
-                                state: \.projects,
-                                action: { .deleteProjectButtonTapped(id: $0, action: $1) }
-                            )
-                        ) {
-                            ProjectItemView(store: $0)
-                        }
-                    }
-                } else {
-                    ZStack {
-                        if viewStore.isInProgress {
-                            ProgressView()
-                        }
-                    }
-
+                HStack(spacing: 0) {
+                    ProjectBoardSideView()
+                        .frame(width: 306)
+                    ProjectBoardMainView(store: store, isCreateNewProjectSheet: $isCreateNewProjectSheet)
                 }
-            }
-            .onAppear {
-                viewStore.send(.onAppear)
+            .sheet(isPresented: viewStore.binding(
+                get: \.isSheetPresented,
+                send: ProjectBoard.Action.setSheet(isPresented:)
+            )) {
+                ProjectCreationView(store: store)
             }
         }
     }
@@ -57,4 +37,3 @@ struct ProjectBoardView: View {
         )
     )
 }
-

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
@@ -22,12 +22,13 @@ struct ProjectBoardView: View {
                     }
                     if viewStore.isSheetPresented {
                         ZStack {
-                            Color.black.opacity(0.5)
+                            Color.black.opacity(0.6)
                                 .frame(width: geometry.size.width, height: geometry.size.height)
                                 .onTapGesture {
                                     viewStore.send(ProjectBoard.Action.setSheet(isPresented: false))
                                 }
                             ProjectCreationView(store: store)
+                                .offset(y: viewStore.isSheetPresented ? 0 : -50)
                         }
                     }
                 }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
@@ -29,8 +29,14 @@ struct ProjectBoardView: View {
                                 }
                             ProjectCreationView(store: store)
                                 .offset(y: viewStore.isSheetPresented ? 0 : -50)
+                                .onExitCommand {
+                                    viewStore.send(ProjectBoard.Action.setSheet(isPresented: false))
+                                }
                         }
                     }
+                }
+                .onExitCommand {
+                    viewStore.send(ProjectBoard.Action.setSheet(isPresented: false))
                 }
             }
         }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
@@ -10,8 +10,8 @@ import ComposableArchitecture
 
 struct ProjectCreationView: View {
     let store: StoreOf<ProjectBoard>
-    @State private var text = ""
     @FocusState private var isTextFieldFocused: Bool
+    @State var tag: Int? = nil
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -58,7 +58,10 @@ struct ProjectCreationView: View {
                                 )
                                 .focused($isTextFieldFocused)
                                 .onSubmit {
-                                    viewStore.send(.createNewProjectButtonTapped)
+                                    if !viewStore.title.isEmpty {
+                                        viewStore.send(.createNewProjectButtonTapped)
+                                        self.tag = 1
+                                    }
                                 }
                                 .font(.custom("Pretendard-Medium", size: 14))
                                 .padding(.leading, 12)
@@ -142,21 +145,27 @@ struct ProjectCreationView: View {
                             .padding(.bottom, 24)
                         Divider()
                             .padding(.bottom, 20)
-                        Button {
-                            viewStore.send(.createNewProjectButtonTapped)
-                        } label: {
-                            RoundedRectangle(cornerRadius: 12)
-                                .frame(width: 328, height: 48)
-                                .foregroundStyle(viewStore.title.isEmpty ? .gray : .blue)
-                                .overlay {
-                                    Text("Go Ahead !")
-                                        .font(.custom("Pretendard-Medium", size: 16))
-                                        .foregroundStyle(viewStore.title.isEmpty ? .black : .white)
-                                }
+                        ZStack {
+                            NavigationLink(destination: TimelineLayoutView(), tag: 1, selection: self.$tag) {
+                                EmptyView()
+                            }
+                            Button {
+                                viewStore.send(.createNewProjectButtonTapped)
+                                self.tag = 1
+                            } label: {
+                                RoundedRectangle(cornerRadius: 12)
+                                    .frame(width: 328, height: 48)
+                                    .foregroundStyle(viewStore.title.isEmpty ? .gray : .blue)
+                                    .overlay {
+                                        Text("Go Ahead !")
+                                            .font(.custom("Pretendard-Medium", size: 16))
+                                            .foregroundStyle(viewStore.title.isEmpty ? .black : .white)
+                                    }
+                            }
+                            .disabled(viewStore.title.isEmpty)
+                            .buttonStyle(PlainButtonStyle())
+                            .padding(.bottom, 9)
                         }
-                        .disabled(viewStore.title.isEmpty)
-                        .buttonStyle(PlainButtonStyle())
-                        .padding(.bottom, 9)
                         HStack(alignment: .center, spacing: 5) {
                             RoundedRectangle(cornerRadius: 4)
                                 .frame(width: 55, height: 22)

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 struct ProjectCreationView: View {
     let store: StoreOf<ProjectBoard>
     @State private var text = ""
+    @FocusState private var isTextFieldFocused: Bool
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -55,6 +56,7 @@ struct ProjectCreationView: View {
                                         send: { .titleChanged($0) }
                                     )
                                 )
+                                .focused($isTextFieldFocused)
                                 .onSubmit {
                                     viewStore.send(.createNewProjectButtonTapped)
                                 }
@@ -145,13 +147,14 @@ struct ProjectCreationView: View {
                         } label: {
                             RoundedRectangle(cornerRadius: 12)
                                 .frame(width: 328, height: 48)
-                                .foregroundStyle(.blue)
+                                .foregroundStyle(viewStore.title.isEmpty ? .gray : .blue)
                                 .overlay {
                                     Text("Go Ahead !")
                                         .font(.custom("Pretendard-Medium", size: 16))
-                                        .foregroundStyle(.white)
+                                        .foregroundStyle(viewStore.title.isEmpty ? .black : .white)
                                 }
                         }
+                        .disabled(viewStore.title.isEmpty)
                         .buttonStyle(PlainButtonStyle())
                         .padding(.bottom, 9)
                         HStack(alignment: .center, spacing: 5) {
@@ -174,6 +177,9 @@ struct ProjectCreationView: View {
                                 .foregroundStyle(.gray)
                         }
                     }
+                }
+                .onAppear {
+                    isTextFieldFocused = true
                 }
         }
     }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
@@ -1,0 +1,182 @@
+//
+//  ProjectItemView.swift
+//  gridy
+//
+//  Created by 제나 on 10/8/23.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+struct ProjectCreationView: View {
+    
+    //    let store: StoreOf<ProjectItem>
+    let store: StoreOf<ProjectBoard>
+    @State private var text = ""
+    
+    var body: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            RoundedRectangle(cornerRadius: 16)
+                .foregroundStyle(.white)
+                .frame(width: 368, height: 448)
+                .overlay {
+                    VStack(alignment: .center, spacing: 0) {
+                        HStack(alignment: .center, spacing: 73) {
+                            Text("Create a new project")
+                                .font(.custom("Pretendard-Bold", size: 16))
+                            HStack(alignment: .center, spacing: 4) {
+                                RoundedRectangle(cornerRadius: 5)
+                                    .frame(width: 30, height: 22)
+                                    .foregroundStyle(.gray.opacity(0.8))
+                                    .overlay {
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .frame(width: 28, height: 18)
+                                            .foregroundStyle(.white)
+                                            .overlay {
+                                                Text("Esc")
+                                                    .font(.custom("Pretendard-SemiBold", size: 12))
+                                                    .foregroundStyle(.gray)
+                                            }
+                                            .offset(y: -1)
+                                    }
+                                Text("to Close tab")
+                                    .font(.custom("Pretendard-Regular", size: 12))
+                                    .foregroundStyle(.gray)
+                            }
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 10)
+                        RoundedRectangle(cornerRadius: 8)
+                            .foregroundStyle(.gray.opacity(0.1))
+                            .frame(width: 328, height: 36)
+                            .overlay {
+                                TextField(
+                                    "Project Name",
+                                    text: viewStore.binding(
+                                        get: \.title,
+                                        send: { .titleChanged($0) }
+                                    )
+                                )
+                                .onSubmit {
+                                    viewStore.send(.createNewProjectButtonTapped)
+                                }
+                                .font(.custom("Pretendard-Medium", size: 14))
+                                .padding(.leading, 12)
+                                .textFieldStyle(.plain)
+                            }
+                            .padding(.bottom, 16)
+                        Divider()
+                            .padding(.bottom, 14)
+                        HStack(alignment: .center, spacing: 220) {
+                            Text("Select Layout")
+                                .font(.custom("Pretendard-SemiBold", size: 14))
+                                .foregroundStyle(.opacity(0.8))
+                            Image(systemName: "questionmark.circle")
+                                .foregroundStyle(.opacity(0.8))
+                                .frame(width: 16, height: 16)
+                        }
+                        .padding(.bottom, 10)
+                        HStack(alignment: .center, spacing: 14) {
+                            RoundedRectangle(cornerRadius: 12)
+                                .foregroundStyle(.blue.opacity(0.1))
+                                .frame(width: 100, height: 120)
+                                .overlay {
+                                    VStack(alignment: .center, spacing: 10) {
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .foregroundStyle(.blue.opacity(0.2))
+                                            .frame(width: 64, height: 64)
+                                            .overlay {
+                                                Image(systemName: "chart.bar.doc.horizontal")
+                                                    .resizable()
+                                                    .foregroundStyle(.blue)
+                                                    .frame(width: 32, height: 38)
+                                            }
+                                        Text("Timeline")
+                                            .font(.custom("Pretendard-Medium", size: 14))
+                                            .foregroundStyle(.blue)
+                                    }
+                                }
+                            RoundedRectangle(cornerRadius: 12)
+                                .foregroundStyle(.gray.opacity(0.1))
+                                .frame(width: 100, height: 120)
+                                .overlay {
+                                    VStack(alignment: .center, spacing: 10) {
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .foregroundStyle(.gray.opacity(0.2))
+                                            .frame(width: 64, height: 64)
+                                            .overlay {
+                                                Image(systemName: "calendar")
+                                                    .resizable()
+                                                    .foregroundStyle(.gray)
+                                                    .frame(width: 36, height: 33)
+                                            }
+                                        Text("Calendar")
+                                            .font(.custom("Pretendard-Medium", size: 14))
+                                            .foregroundStyle(.gray)
+                                    }
+                                }
+                            RoundedRectangle(cornerRadius: 12)
+                                .foregroundStyle(.gray.opacity(0.1))
+                                .frame(width: 100, height: 120)
+                                .overlay {
+                                    VStack(alignment: .center, spacing: 10) {
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .foregroundStyle(.gray.opacity(0.2))
+                                            .frame(width: 64, height: 64)
+                                            .overlay {
+                                                Image(systemName: "point.3.filled.connected.trianglepath.dotted")
+                                                    .resizable()
+                                                    .foregroundStyle(.gray)
+                                                    .frame(width: 36, height: 30)
+                                            }
+                                        Text("Scheme")
+                                            .font(.custom("Pretendard-Medium", size: 14))
+                                            .foregroundStyle(.gray)
+                                    }
+                                }
+                        }
+                        .padding(.bottom, 16)
+                        Text("We are currently offering the **Timeline Layout** in a \rclosed beta version. <Message>")
+                            .font(.custom("Pretendard-Medium", size: 14))
+                            .foregroundStyle(.gray)
+                            .padding(.bottom, 24)
+                        Divider()
+                            .padding(.bottom, 20)
+                        Button {
+                            viewStore.send(.createNewProjectButtonTapped)
+                        } label: {
+                            RoundedRectangle(cornerRadius: 12)
+                                .frame(width: 328, height: 48)
+                                .foregroundStyle(.blue)
+                                .overlay {
+                                    Text("Go Ahead !")
+                                        .font(.custom("Pretendard-Medium", size: 16))
+                                        .foregroundStyle(.white)
+                                }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .padding(.bottom, 9)
+                        HStack(alignment: .center, spacing: 5) {
+                            RoundedRectangle(cornerRadius: 4)
+                                .frame(width: 55, height: 22)
+                                .foregroundStyle(.gray.opacity(0.8))
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 4)
+                                        .frame(width: 53, height: 18)
+                                        .foregroundStyle(.white)
+                                        .overlay {
+                                            Text("↵ Enter")
+                                                .font(.custom("Pretendard-SemiBold", size: 12))
+                                                .foregroundStyle(.gray)
+                                        }
+                                        .offset(y: -1)
+                                }
+                            Text("to Create a proejct")
+                                .font(.custom("Pretendard-Regular", size: 12))
+                                .foregroundStyle(.gray)
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
@@ -146,6 +146,7 @@ struct ProjectCreationView: View {
                         Divider()
                             .padding(.bottom, 20)
                         ZStack {
+                            //TODO: NavigationLink 방식은 Store 이용하기
                             NavigationLink(destination: TimelineLayoutView(), tag: 1, selection: self.$tag) {
                                 EmptyView()
                             }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectCreationView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 import ComposableArchitecture
 
 struct ProjectCreationView: View {
-    
-    //    let store: StoreOf<ProjectItem>
     let store: StoreOf<ProjectBoard>
     @State private var text = ""
     

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectItemView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectItemView.swift
@@ -2,7 +2,7 @@
 //  ProjectItemView.swift
 //  gridy
 //
-//  Created by 제나 on 10/8/23.
+//  Created by xnoag on 10/17/23.
 //
 
 import SwiftUI
@@ -11,37 +11,75 @@ import ComposableArchitecture
 struct ProjectItemView: View {
     
     let store: StoreOf<ProjectItem>
-    
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            VStack {
-                TextField(
-                    viewStore.project.title,
-                    text: viewStore.binding(
-                        get: \.project.title,
-                        send: ProjectItem.Action.titleChanged
+        RoundedRectangle(cornerRadius: 6)
+            .frame(height: 108)
+            .foregroundStyle(.white)
+            .overlay {
+                VStack(alignment: .leading, spacing: 0) {
+                    HStack(alignment: .center, spacing: 0) {
+                        Text("Last updated on **2023.10.17**")
+                            .font(.custom("Pretendard-Regular", size: 12))
+                            .foregroundStyle(.gray)
+                            .padding(.leading, 10)
+                            .padding(.trailing, 4)
+                        Spacer()
+                        Button {
+                            // 더보기 버튼
+                        } label: {
+                            RoundedRectangle(cornerRadius: 6)
+                                .frame(width: 20, height: 20)
+                                .foregroundStyle(.gray.opacity(0.1))
+                                .overlay {
+                                    Image(systemName: "ellipsis")
+                                        .foregroundStyle(.gray)
+                                }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .padding(.vertical, 4)
+                        .padding(.trailing, 4)
+                    }
+                    .background(.gray.opacity(0.1))
+                    .clipShape(
+                        .rect(
+                            topLeadingRadius: 6,
+                            bottomLeadingRadius: 0,
+                            bottomTrailingRadius: 0,
+                            topTrailingRadius: 6,
+                            style: .continuous
+                        )
                     )
-                )
-                Text(viewStore.project.id)
-                Text(viewStore.project.ownerUid)
-                Text("생성일 \(viewStore.project.createdDate.description)")
-                Text("수정일 \(viewStore.project.lastModifiedDate.description)")
-                Button("프로젝트 삭제") {
-                    viewStore.$delete.wrappedValue.toggle()
+                    .frame(height: 28)
+                    Text("Project Name")
+                        .font(.custom("Pretendard-Bold", size: 20))
+                        .multilineTextAlignment(.leading)
+                        .padding(.leading, 12)
+                        .padding(.top, 12)
+                        .padding(.bottom, 11)
+                    HStack(alignment: .center, spacing: 0) {
+                        Text("2023.10.01 ~ 2023.11.14")
+                            .font(.custom("Pretendard-SemiBold", size: 12))
+                            .multilineTextAlignment(.leading)
+                            .padding(.horizontal, 8)
+                            .frame(height: 24)
+                            .background(.gray.opacity(0.3))
+                            .cornerRadius(6)
+                            .padding(.trailing, 6)
+                        Text("45 Days")
+                            .font(.custom("Pretendard-SemiBold", size: 12))
+                            .multilineTextAlignment(.leading)
+                            .padding(.horizontal, 8)
+                            .frame(height: 24)
+                            .background(.gray.opacity(0.3))
+                            .cornerRadius(6)
+                    }
+                    .padding(.leading, 12)
+                    .padding(.bottom, 9)
                 }
-                .keyboardShortcut(.delete)
             }
-            .padding()
-            .border(.white)
-        }
     }
 }
 
 #Preview {
-    ProjectItemView(
-        store: Store(
-            initialState: ProjectItem.State(),
-            reducer: { ProjectItem() }
-        )
-    )
+    ProjectItemView(store: StoreOf<ProjectItem>(initialState: ProjectItem.State(), reducer: { ProjectItem() }))
 }

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectItemView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectItemView.swift
@@ -11,72 +11,75 @@ import ComposableArchitecture
 struct ProjectItemView: View {
     
     let store: StoreOf<ProjectItem>
+    
     var body: some View {
-        RoundedRectangle(cornerRadius: 6)
-            .frame(height: 108)
-            .foregroundStyle(.white)
-            .overlay {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(alignment: .center, spacing: 0) {
-                        Text("Last updated on **2023.10.17**")
-                            .font(.custom("Pretendard-Regular", size: 12))
-                            .foregroundStyle(.gray)
-                            .padding(.leading, 10)
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            RoundedRectangle(cornerRadius: 6)
+                .frame(height: 108)
+                .foregroundStyle(.white)
+                .overlay {
+                    VStack(alignment: .leading, spacing: 0) {
+                        HStack(alignment: .center, spacing: 0) {
+                            Text("Last updated on **\(viewStore.project.lastModifiedDate.formattedDate)**")
+                                .font(.custom("Pretendard-Regular", size: 12))
+                                .foregroundStyle(.gray)
+                                .padding(.leading, 10)
+                                .padding(.trailing, 4)
+                            Spacer()
+                            Button {
+                                // 더보기 버튼
+                            } label: {
+                                RoundedRectangle(cornerRadius: 6)
+                                    .frame(width: 20, height: 20)
+                                    .foregroundStyle(.gray.opacity(0.1))
+                                    .overlay {
+                                        Image(systemName: "ellipsis")
+                                            .foregroundStyle(.gray)
+                                    }
+                            }
+                            .buttonStyle(PlainButtonStyle())
+                            .padding(.vertical, 4)
                             .padding(.trailing, 4)
-                        Spacer()
-                        Button {
-                            // 더보기 버튼
-                        } label: {
-                            RoundedRectangle(cornerRadius: 6)
-                                .frame(width: 20, height: 20)
-                                .foregroundStyle(.gray.opacity(0.1))
-                                .overlay {
-                                    Image(systemName: "ellipsis")
-                                        .foregroundStyle(.gray)
-                                }
                         }
-                        .buttonStyle(PlainButtonStyle())
-                        .padding(.vertical, 4)
-                        .padding(.trailing, 4)
-                    }
-                    .background(.gray.opacity(0.1))
-                    .clipShape(
-                        .rect(
-                            topLeadingRadius: 6,
-                            bottomLeadingRadius: 0,
-                            bottomTrailingRadius: 0,
-                            topTrailingRadius: 6,
-                            style: .continuous
+                        .background(.gray.opacity(0.1))
+                        .clipShape(
+                            .rect(
+                                topLeadingRadius: 6,
+                                bottomLeadingRadius: 0,
+                                bottomTrailingRadius: 0,
+                                topTrailingRadius: 6,
+                                style: .continuous
+                            )
                         )
-                    )
-                    .frame(height: 28)
-                    Text("Project Name")
-                        .font(.custom("Pretendard-Bold", size: 20))
-                        .multilineTextAlignment(.leading)
+                        .frame(height: 28)
+                        Text(viewStore.project.title)
+                            .font(.custom("Pretendard-Bold", size: 20))
+                            .multilineTextAlignment(.leading)
+                            .padding(.leading, 12)
+                            .padding(.top, 12)
+                            .padding(.bottom, 11)
+                        HStack(alignment: .center, spacing: 0) {
+                            Text("2023.10.01 ~ 2023.11.14")
+                                .font(.custom("Pretendard-SemiBold", size: 12))
+                                .multilineTextAlignment(.leading)
+                                .padding(.horizontal, 8)
+                                .frame(height: 24)
+                                .background(.gray.opacity(0.3))
+                                .cornerRadius(6)
+                                .padding(.trailing, 6)
+                            Text("45 Days")
+                                .font(.custom("Pretendard-SemiBold", size: 12))
+                                .multilineTextAlignment(.leading)
+                                .padding(.horizontal, 8)
+                                .frame(height: 24)
+                                .background(.gray.opacity(0.3))
+                                .cornerRadius(6)
+                        }
                         .padding(.leading, 12)
-                        .padding(.top, 12)
-                        .padding(.bottom, 11)
-                    HStack(alignment: .center, spacing: 0) {
-                        Text("2023.10.01 ~ 2023.11.14")
-                            .font(.custom("Pretendard-SemiBold", size: 12))
-                            .multilineTextAlignment(.leading)
-                            .padding(.horizontal, 8)
-                            .frame(height: 24)
-                            .background(.gray.opacity(0.3))
-                            .cornerRadius(6)
-                            .padding(.trailing, 6)
-                        Text("45 Days")
-                            .font(.custom("Pretendard-SemiBold", size: 12))
-                            .multilineTextAlignment(.leading)
-                            .padding(.horizontal, 8)
-                            .frame(height: 24)
-                            .background(.gray.opacity(0.3))
-                            .cornerRadius(6)
+                        .padding(.bottom, 9)
                     }
-                    .padding(.leading, 12)
-                    .padding(.bottom, 9)
                 }
-            }
+        }
     }
 }
 

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectItemView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectItemView.swift
@@ -27,7 +27,7 @@ struct ProjectItemView: View {
                                 .padding(.trailing, 4)
                             Spacer()
                             Button {
-                                // 더보기 버튼
+                                //TODO: 더보기 버튼
                             } label: {
                                 RoundedRectangle(cornerRadius: 6)
                                     .frame(width: 20, height: 20)

--- a/gridy/Sources/gridyApp.swift
+++ b/gridy/Sources/gridyApp.swift
@@ -17,13 +17,7 @@ struct GridyApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                ProjectBoardView(
-                    store: Store(
-                        initialState: ProjectBoard.State(),
-                        reducer: { ProjectBoard() }
-                    )
-                )
-//                ContentView()
+                ContentView()
 //                TimelineLayoutView()
             }
         }

--- a/gridy/Sources/gridyApp.swift
+++ b/gridy/Sources/gridyApp.swift
@@ -17,7 +17,8 @@ struct GridyApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                ContentView()
+                ProjectBoardMainView()
+//                ContentView()
 //                TimelineLayoutView()
             }
         }

--- a/gridy/Sources/gridyApp.swift
+++ b/gridy/Sources/gridyApp.swift
@@ -17,7 +17,12 @@ struct GridyApp: App {
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                ProjectBoardMainView()
+                ProjectBoardView(
+                    store: Store(
+                        initialState: ProjectBoard.State(),
+                        reducer: { ProjectBoard() }
+                    )
+                )
 //                ContentView()
 //                TimelineLayoutView()
             }


### PR DESCRIPTION
# Description
close #34
1. ProjectBoardView는 ProjectBoardSideView와 ProjectBoardMainView로 구성되게 구현했습니다.
2. 실제로 Project를 생성하고 LazyVGrid로 저장되게 구현했습니다.
3. 각 ProjectItem을 클릭했을 때, TimelineLayoutView로 Navigate 되도록 구현했습니다. (타이틀 등의 정보는 전달 되지 않고, 우선 TimelineLayoutView로만 넘어가게 하는 상태입니다.)

# Screenshots & Demo
![나의 동영상 (3)](https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-Ampersand/assets/125735850/3449ad50-8a6f-4f2e-9bc8-c2299f3d7075)
