### PR TITLE
[feat][#32] listArea createPlan 붙이기

### DIFF
--- a/gridy.xcodeproj/project.pbxproj
+++ b/gridy.xcodeproj/project.pbxproj
@@ -20,8 +20,9 @@
 		975A620D2ACE946A00DE31AB /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975A620C2ACE946A00DE31AB /* Date+Extension.swift */; };
 		975A620F2ACE950200DE31AB /* HolidayUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975A620E2ACE950200DE31AB /* HolidayUtil.swift */; };
 		975A62132ACE970800DE31AB /* DayGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975A62122ACE970800DE31AB /* DayGridView.swift */; };
-		9784DB542AECEB88002EB52F /* LayerControlAreaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9784DB532AECEB88002EB52F /* LayerControlAreaView.swift */; };
 		97806BB52AE15ACC0044FA0C /* ListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97806BB42AE15ACC0044FA0C /* ListItemView.swift */; };
+		9783F6D82AEFA04100176700 /* FirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9783F6D72AEFA04100176700 /* FirestoreService.swift */; };
+		9784DB542AECEB88002EB52F /* LayerControlAreaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9784DB532AECEB88002EB52F /* LayerControlAreaView.swift */; };
 		97BD1B672AD14F8C000F00FA /* ScrollDatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97BD1B662AD14F8C000F00FA /* ScrollDatePickerView.swift */; };
 		97C419DC2AE2CAEB00501321 /* ListAreaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C419DB2AE2CAEB00501321 /* ListAreaView.swift */; };
 		AD01D50C2ACC7B5E00474E7A /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD01D50B2ACC7B5E00474E7A /* String+Extension.swift */; };
@@ -98,8 +99,9 @@
 		975A620C2ACE946A00DE31AB /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		975A620E2ACE950200DE31AB /* HolidayUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HolidayUtil.swift; sourceTree = "<group>"; };
 		975A62122ACE970800DE31AB /* DayGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayGridView.swift; sourceTree = "<group>"; };
-		9784DB532AECEB88002EB52F /* LayerControlAreaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerControlAreaView.swift; sourceTree = "<group>"; };
 		97806BB42AE15ACC0044FA0C /* ListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemView.swift; sourceTree = "<group>"; };
+		9783F6D72AEFA04100176700 /* FirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreService.swift; sourceTree = "<group>"; };
+		9784DB532AECEB88002EB52F /* LayerControlAreaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerControlAreaView.swift; sourceTree = "<group>"; };
 		97BD1B662AD14F8C000F00FA /* ScrollDatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollDatePickerView.swift; sourceTree = "<group>"; };
 		97C419DB2AE2CAEB00501321 /* ListAreaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListAreaView.swift; sourceTree = "<group>"; };
 		AD01D50B2ACC7B5E00474E7A /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 			children = (
 				AD52FE9B2AC95FBB00AA001F /* APIClient.swift */,
 				ADA3E9CF2AD07AF800303958 /* APIService.swift */,
+				9783F6D72AEFA04100176700 /* FirestoreService.swift */,
 				AD96ED432AD30312005D197B /* APIError.swift */,
 			);
 			path = Network;
@@ -591,6 +594,7 @@
 				EE909A6E2AC3D4E900C9AAF0 /* ScheduleIndexAreaView.swift in Sources */,
 				8A1D0C502AC3F79300C7FCF8 /* Font.swift in Sources */,
 				ADA3E9D02AD07AF800303958 /* APIService.swift in Sources */,
+				9783F6D82AEFA04100176700 /* FirestoreService.swift in Sources */,
 				EE909A542AC3CEF200C9AAF0 /* TabBarAreaView.swift in Sources */,
 				EE5C207C2AE15685005D2D7E /* ProjectSideItemView.swift in Sources */,
 				AD8ECB902ABC7CA10040A0B8 /* ContentView.swift in Sources */,

--- a/gridy/Sources/Network/APIService.swift
+++ b/gridy/Sources/Network/APIService.swift
@@ -170,7 +170,7 @@ extension APIService {
                                newLayerIndex == currentLayerCount,
                                prevLayer[index] == parentPlanID {
                                 // TODO: - 입력받은 row에 들어가도록 수정
-                                // 첫 순회때 새 플랜이 생성될 row 인덱스 조회
+                                // TODO: - 첫 순회때 새 플랜이 생성될 row 인덱스 조회
                                 rowIndex = index
                             }
                             let prevLayerPlanID = prevLayer[index]

--- a/gridy/Sources/Network/APIService.swift
+++ b/gridy/Sources/Network/APIService.swift
@@ -355,9 +355,9 @@ extension APIService {
             var projectMap = try await FirestoreService.projectCollectionPath.document(projectID).getDocument(as: Project.self).map
             let currentProjectMapLayerSize = projectMap.count
             
-            if (currentProjectMapLayerSize - 1) < layerIndex {
+            if (currentProjectMapLayerSize - 1) < layerIndex + 1{
                 /// 이미 있는 레이어와 레이어 사이에 생성하는 것이 아닌, map에 아직 없는 레이어를 추가하는 경우: 레이어만 추가
-                for currentLayerIndex in currentProjectMapLayerSize...layerIndex {
+                for currentLayerIndex in currentProjectMapLayerSize...layerIndex + 1 {
                     projectMap["\(currentLayerIndex)"] = []
                 }
             } else {

--- a/gridy/Sources/Network/APIService.swift
+++ b/gridy/Sources/Network/APIService.swift
@@ -15,8 +15,8 @@ struct APIService {
     /// Project
     var createProject: (String) async throws -> Void
     var readAllProjects: () async throws -> [Project]
-    var updateProjectTitle: @Sendable (_ id: String, _ newTitle: String) async throws -> Void
-    var deleteProject: @Sendable (_ id: String) async throws -> Void
+    var updateProjectTitle: @Sendable (String, String) async throws -> Void
+    var deleteProject: @Sendable (String) async throws -> Void
     
     /// Plan Type
     var readAllPlanTypes: (String) async throws -> [PlanType]
@@ -25,7 +25,7 @@ struct APIService {
     var deletePlanType: @Sendable (String, String) async throws -> Void
     
     /// Plan
-    var createPlan: @Sendable (Plan, Int, String) async throws -> [String: [String]]
+    var createPlan: @Sendable (Plan, Int, Int, String) async throws -> [String: [String]]
     var deletePlan: @Sendable (String, Int, Bool, String) async throws -> [String: [String]]
     var updatePlan: @Sendable (String, String, String) async throws -> Plan
     var readAllPlans: @Sendable (String) async throws -> [String: Plan]
@@ -48,7 +48,7 @@ struct APIService {
         createPlanType: @escaping @Sendable (PlanType, String, String) async throws -> String,
         deletePlanType: @escaping @Sendable (String, String) async throws -> Void,
         
-        createPlan: @escaping @Sendable (Plan, Int, String) async throws -> [String: [String]],
+        createPlan: @escaping @Sendable (Plan, Int, Int, String) async throws -> [String: [String]],
         deletePlan: @escaping @Sendable (String, Int, Bool, String) async throws -> [String: [String]],
         updatePlan: @escaping @Sendable (String, String, String) async throws -> Plan,
         readAllPlans: @escaping @Sendable (String) async throws -> [String: Plan],
@@ -56,7 +56,7 @@ struct APIService {
         createLane: @escaping @Sendable (Int, Int, Bool, String, String) async throws -> [String: [String]],
         deleteLane: @escaping @Sendable (String, Bool, String) async throws -> [String: [String]],
         
-        createLayer: @escaping @Sendable (_ layerIndex: Int, _ projectID: String) async throws -> [String: [String]]
+        createLayer: @escaping @Sendable (Int, String) async throws -> [String: [String]]
     ) {
         self.createProject = createProject
         self.readAllProjects = readAllProjects
@@ -71,7 +71,7 @@ struct APIService {
         self.createPlan = createPlan
         self.deletePlan = deletePlan
         self.updatePlan = updatePlan
-        self.readAllPlans = readAllPlans 
+        self.readAllPlans = readAllPlans
         
         self.createLane = createLane
         self.deleteLane = deleteLane
@@ -81,85 +81,23 @@ struct APIService {
 }
 
 extension APIService {
-    /// Currently authenticated user
-    static var uid: String {
-        get throws {
-            guard let uid = Auth.auth().currentUser?.uid else { throw APIError.noAuthenticatedUser }
-            return uid
-        }
-    }
-    
-    /// Base firestore path for API Service
-    static var basePath: DocumentReference {
-        get throws {
-            let firestore = Firestore.firestore().collection("ProjectCollection")
-            return firestore.document(try uid)
-        }
-    }
-    
-    static var projectCollectionPath: CollectionReference {
-        get throws {
-            return try basePath.collection("Projects")
-        }
-    }
-    
-    static func planCollectionPath(_ projectID: String) throws -> CollectionReference {
-        return try projectCollectionPath.document(projectID).collection("Plans")
-    }
-    
-    static func planTypeCollectionPath(_ projectID: String) throws -> CollectionReference {
-        return try projectCollectionPath.document(projectID).collection("PlanTypes")
-    }
-    
-    static func laneCollectionPath(_ projectID: String) throws -> CollectionReference {
-        return try projectCollectionPath.document(projectID).collection("Lanes")
-    }
-    
-    static func deletePlanWithAllChild(
-        currentPlan: Plan,
-        currentLayerIndex: Int,
-        _ projectMap: inout [String: [String]],
-        projectID: String
-    ) async throws {
-        for laneID in currentPlan.laneIDs {
-            /// plan이 가진 lane들에 속한 plan을 먼저 삭제, 재귀적으로 최하위까지 삭제
-            let currentLane = try await laneCollectionPath(projectID).document(laneID).getDocument(as: Lane.self)
-            if let childIDs = currentLane.childIDs {
-                for planID in childIDs {
-                    let nextPlan = try await planCollectionPath(projectID).document(planID).getDocument(as: Plan.self)
-                    try await deletePlanWithAllChild(
-                        currentPlan: nextPlan,
-                        currentLayerIndex: currentLayerIndex + 1,
-                        &projectMap,
-                        projectID: projectID
-                    )
-                    try await planCollectionPath(projectID).document(planID).delete()
-                }
-            }
-            /// lane들을 삭제
-            try await laneCollectionPath(projectID).document(laneID).delete()
-        }
-        projectMap["\(currentLayerIndex)"]!.remove(at: projectMap["\(currentLayerIndex)"]!.firstIndex(of: currentPlan.id)!)
-    }
-    
     static let liveValue = Self(
         // MARK: - Project
         createProject: { title in
-            let id = try projectCollectionPath.document().documentID
+            let id = try FirestoreService.projectCollectionPath.document().documentID
             let data = ["id": id,
                         "title": title,
-                        "ownerUid": try uid,
+                        "ownerUid": try FirestoreService.uid,
                         "createdDate": Date(),
                         "lastModifiedDate": Date(),
                         "map": ["0": [],
                                 "1": [],
                                 "2": []]] as [String: Any?]
-            try projectCollectionPath.document(id).setData(data as [String: Any])
-            
+            try FirestoreService.projectCollectionPath.document(id).setData(data as [String: Any])
         },
         readAllProjects: {
             do {
-                let snapshots = try await projectCollectionPath
+                let snapshots = try await FirestoreService.projectCollectionPath
                     .getDocuments()
                     .documents
                     .map { try $0.data(as: Project.self) }
@@ -168,75 +106,60 @@ extension APIService {
             } catch {
                 throw APIError.noResponseResult
             }
-            
         },
         updateProjectTitle: { id, newTitle in
-            try projectCollectionPath.document(id).updateData(["title": newTitle])
-            try projectCollectionPath.document(id).updateData(["lastModifiedDate": Date()])
+            try FirestoreService.projectCollectionPath.document(id).updateData(["title": newTitle])
+            try FirestoreService.projectCollectionPath.document(id).updateData(["lastModifiedDate": Date()])
             
         },
         deleteProject: { id in
-            try projectCollectionPath.document(id).delete()
+            try FirestoreService.projectCollectionPath.document(id).delete()
             
         },
-        
         // MARK: - Plan type
         readAllPlanTypes: { projectID in
-            return try await planTypeCollectionPath(projectID)
-                .getDocuments()
-                .documents
-                .map { try $0.data(as: PlanType.self) }
-            
+            return try await FirestoreService.getDocuments(projectID, .planTypes, PlanType.self) as! [PlanType]
         },
         searchPlanTypes: { keyword, projectID in
-            do {
-                return try await planTypeCollectionPath(projectID)
-                    .getDocuments()
-                    .documents
-                    .map { try $0.data(as: PlanType.self) }
-                    .filter { $0.title.contains(keyword) }
-            } catch {
-                throw APIError.noResponseResult
-            }
-            
+            let snapshots = try await FirestoreService.getDocuments(projectID, .planTypes, PlanType.self) as! [PlanType]
+            return snapshots.filter { $0.title.contains(keyword) }
         },
         createPlanType: { target, planID, projectID in
-            let id = try planTypeCollectionPath(projectID).document().documentID
+            let id = try FirestoreService.getNewDocumentID(projectID, .planTypes)
             let data = ["id": id,
                         "title": target.title,
                         "colorCode": target.colorCode] as [String: Any]
-            try planTypeCollectionPath(projectID).document(id).setData(data)
-            try planCollectionPath(projectID).document(planID).updateData(["planTypeID": id])
+            try await FirestoreService.setDocumentData(projectID, .planTypes, id, data)
+            try await FirestoreService.updateDocumentData(projectID, .plans, planID, ["planTypeID": id])
             return id
-            
         },
         deletePlanType: { typeID, projectID in
-            try planTypeCollectionPath(projectID).document(typeID).delete()
+            try await FirestoreService.deleteDocument(projectID, .planTypes, typeID)
         },
-        
         // MARK: - Plan
-        createPlan: { target, layerIndex, projectID in
-            let targetID = try planCollectionPath(projectID).document().documentID
+        createPlan: { target, layerIndex, rowIndex, projectID in
+            let targetID = try FirestoreService.getNewDocumentID(projectID, .plans)
             /// plan에 대한  lane 생성
-            let newLaneID = try laneCollectionPath(projectID).document().documentID
+            let newLaneID = try FirestoreService.getNewDocumentID(projectID, .lanes)
             var data = ["id": newLaneID,
                         "childIDs": [],
                         "ownerID": targetID,
                         "periods": []] as [String: Any?]
-            try await laneCollectionPath(projectID).document(newLaneID).setData(data as [String: Any])
+            try await FirestoreService.setDocumentData(projectID, .lanes, newLaneID, data as [String: Any])
             
             /// parentPlanID를 조회
             var parentPlanID: String?
             if let parentLaneID = target.parentLaneID {
-                parentPlanID = try await laneCollectionPath(projectID).document(parentLaneID).getDocument(as: Lane.self).ownerID
+                parentPlanID = (try await FirestoreService.getDocument(projectID, .lanes, parentLaneID, Lane.self) as! Lane).ownerID
             }
             
             /// map 업데이트
-            var map = try await projectCollectionPath.document(projectID).getDocument(as: Project.self).map
+            var map = try await FirestoreService.projectCollectionPath.document(projectID).getDocument(as: Project.self).map
             /// 레이어를 생성해야 하는 경우인지 확인
             let currentLayerCount = map.count
             if layerIndex >= currentLayerCount {
                 var upperLaneID: String?
+                // TODO: - parameter랑 이름 겹침
                 var rowIndex = -1
                 for newLayerIndex in currentLayerCount...layerIndex {
                     map["\(newLayerIndex)"] = []
@@ -246,12 +169,13 @@ extension APIService {
                             if let parentPlanID = parentPlanID,
                                newLayerIndex == currentLayerCount,
                                prevLayer[index] == parentPlanID {
+                                // TODO: - 입력받은 row에 들어가도록 수정
                                 // 첫 순회때 새 플랜이 생성될 row 인덱스 조회
                                 rowIndex = index
                             }
                             let prevLayerPlanID = prevLayer[index]
                             
-                            let newPlanID = (layerIndex == newLayerIndex && rowIndex == index) ? targetID : try planCollectionPath(projectID).document().documentID
+                            let newPlanID = (layerIndex == newLayerIndex && rowIndex == index) ? targetID : try FirestoreService.getNewDocumentID(projectID, .plans)
                             var dummyPlan = Plan(id: newPlanID, periods: [:], laneIDs: [newLaneID])
                             
                             if prevLayerPlanID == parentPlanID,
@@ -259,8 +183,7 @@ extension APIService {
                                 dummyPlan = target
                                 dummyPlan.laneIDs = [newLaneID]
                             }
-                            let newLaneID = try laneCollectionPath(projectID).document().documentID
-                            
+                            let newLaneID = try FirestoreService.getNewDocumentID(projectID, .lanes)
                             data = ["id": dummyPlan.id,
                                     "planTypeID": dummyPlan.planTypeID,
                                     "parentLaneID": dummyPlan.parentLaneID,
@@ -268,10 +191,10 @@ extension APIService {
                                     "description": dummyPlan.description,
                                     "laneIDs": [newLaneID]] as [String: Any?]
                             
-                            try await planCollectionPath(projectID).document(dummyPlan.id).setData(data as [String: Any])
-                            try await laneCollectionPath(projectID).document(newLaneID).setData(["id": newLaneID, "ownerID": dummyPlan.id])
+                            try await FirestoreService.setDocumentData(projectID, .plans, dummyPlan.id, data as [String: Any])
+                            try await FirestoreService.setDocumentData(projectID, .lanes, newLaneID, ["id": newLaneID, "ownerID": dummyPlan.id])
                             if let upperLaneID = upperLaneID {
-                                try await laneCollectionPath(projectID).document(upperLaneID).updateData(["childIDs": dummyPlan.id])
+                                try await FirestoreService.updateDocumentData(projectID, .lanes, upperLaneID, ["childIDs": dummyPlan.id])
                             }
                             map["\(newLayerIndex)"]![index] = dummyPlan.id
                             
@@ -282,35 +205,27 @@ extension APIService {
                         }
                     }
                 }
-                try await projectCollectionPath.document(projectID).updateData(["map": map])
+                try await FirestoreService.projectCollectionPath.document(projectID).updateData(["map": map])
                 return map
             }
             
             /// 새로운 레인을 생성하는 경우 == parentLane이 없는 경우
             if parentPlanID == nil {
-                if layerIndex == 0 { /// root인 경우
-                    map["0"]!.append(targetID)
-                    data = ["id": targetID,
-                            "planTypeID": target.planTypeID,
-                            "parentLaneID": target.parentLaneID,
-                            "periods": target.periods.count == 0 ? [:] : ["0": target.periods[0]],
-                            "description": target.description,
-                            "laneIDs": [newLaneID]] as [String: Any?]
-                    
-                    try await planCollectionPath(projectID).document(targetID).setData(data as [String: Any])
-                } else { /// root가 아니고 parentLane이 없는 경우
-                    var prevLayerLaneID: String?
-                    for currentLayerIndex in 0...layerIndex {
-                        let newLaneID = try laneCollectionPath(projectID).document().documentID
-                        var dummyPlan = Plan(id: try planCollectionPath(projectID).document().documentID, periods: [:], laneIDs: [newLaneID])
-                        if currentLayerIndex == layerIndex {
+                var prevLayerLaneID: String?
+                for currentLayerIndex in 0..<currentLayerCount {
+                    let dummyLaneCountExceptTarget = rowIndex - (map["\(currentLayerIndex)"]!.count - 1)
+                    for currentLaneIndex in 0..<dummyLaneCountExceptTarget {
+                        let newLaneID = try FirestoreService.getNewDocumentID(projectID, .lanes)
+                        var dummyPlan = Plan(id: try FirestoreService.getNewDocumentID(projectID, .plans), periods: [:], laneIDs: [newLaneID])
+                        if currentLayerIndex == layerIndex,
+                           currentLaneIndex == dummyLaneCountExceptTarget - 1 {
                             dummyPlan = target
                             dummyPlan.id = targetID
                             dummyPlan.laneIDs = [newLaneID]
                         }
-                        try await laneCollectionPath(projectID).document(newLaneID).setData(["id": newLaneID, "ownerID": dummyPlan.id])
+                        try await FirestoreService.setDocumentData(projectID, .lanes, newLaneID, ["id": newLaneID, "ownerID": dummyPlan.id])
                         if let prevLayerLaneID = prevLayerLaneID {
-                            try await laneCollectionPath(projectID).document(prevLayerLaneID).updateData(["childIDs": FieldValue.arrayUnion([dummyPlan.id])])
+                            try await FirestoreService.updateDocumentData(projectID, .lanes, prevLayerLaneID, ["childIDs": FieldValue.arrayUnion([dummyPlan.id])])
                         }
                         data = ["id": targetID,
                                 "planTypeID": dummyPlan.planTypeID,
@@ -318,51 +233,75 @@ extension APIService {
                                 "periods": dummyPlan.periods.count == 0 ? [:] : ["0": dummyPlan.periods[0]],
                                 "description": dummyPlan.description,
                                 "laneIDs": [newLaneID]] as [String: Any?]
-                        try await planCollectionPath(projectID).document(targetID).setData(data as [String: Any])
+                        try await FirestoreService.setDocumentData(projectID, .plans, targetID, data as [String: Any])
                         prevLayerLaneID = newLaneID
                         map["\(currentLayerIndex)"]!.append(dummyPlan.id)
                     }
                 }
             }
-            try await projectCollectionPath.document(projectID).updateData(["map": map])
+            try await FirestoreService.projectCollectionPath.document(projectID).updateData(["map": map])
             return map
         },
         deletePlan: { planID, layerIndex, deleteAll, projectID in
-            let currentPlan = try await planCollectionPath(projectID).document(planID).getDocument(as: Plan.self)
-            var projectMap = try await projectCollectionPath.document(projectID).getDocument(as: Project.self).map
+            let currentPlan = try await FirestoreService.getDocument(projectID, .plans, planID, Plan.self) as! Plan
+            var projectMap = try await FirestoreService.projectCollectionPath.document(projectID).getDocument(as: Project.self).map
             if deleteAll {
-                /// 하위 레이어의 자식 plan들을 모두 삭제하는 경우
-                try await APIService.deletePlanWithAllChild(
-                    currentPlan: currentPlan,
-                    currentLayerIndex: layerIndex,
-                    &projectMap,
-                    projectID: projectID
-                )
-                
-                /// plan이 속해있던 parentLane에서 삭제
+                /// plan이 속해있던 parent의 childPlan의 개수가 2이상이라면 아예 삭제
+                /// childPlan의 개수를 알아보자 ..;;
+                var parentsChildsID = Set<String>()
                 if let parentLaneID = currentPlan.parentLaneID {
-                    if var parentLaneChildIDs = try await laneCollectionPath(projectID).document(parentLaneID).getDocument(as: Lane.self).childIDs {
-                        let childIDsWithoutTargetPlanID = parentLaneChildIDs.remove(at: parentLaneChildIDs.firstIndex(of: planID)!)
-                        try await laneCollectionPath(projectID).document(parentLaneID).updateData(["childIDs": childIDsWithoutTargetPlanID])
+                    let parentPlanID = (try await FirestoreService.getDocument(projectID, .lanes, parentLaneID, Lane.self) as! Lane).ownerID
+                    let parentsLaneIDs = (try await FirestoreService.getDocument(projectID, .plans, parentPlanID, Plan.self) as! Plan).laneIDs
+                    for parentsLaneID in parentsLaneIDs {
+                        if let currentLanesChildIDs = (try await FirestoreService.getDocument(projectID, .lanes, parentsLaneID, Lane.self) as! Lane).childIDs {
+                            for currentLanesChildID in currentLanesChildIDs {
+                                parentsChildsID.insert(currentLanesChildID)
+                            }
+                        }
+                        if parentsChildsID.count > 1 { break }
                     }
                 }
-                /// plan을 삭제
-                try await planCollectionPath(projectID).document(planID).delete()
+                
+                if parentsChildsID.count > 1 {
+                    /// 하위 레이어의 자식 plan들을 모두 삭제하는 경우
+                    try await APIService.deletePlanWithAllChild(
+                        currentPlan: currentPlan,
+                        currentLayerIndex: layerIndex,
+                        &projectMap,
+                        projectID: projectID
+                    )
+                    try await FirestoreService.deleteDocument(projectID, .plans, planID)
+                    projectMap["\(layerIndex)"]!.remove(at: projectMap["\(layerIndex)"]!.firstIndex(of: planID)!)
+                } else {
+                    /// parent plan이 가진 plan이 이것 하나뿐이기 때문에 타겟 플랜은 비우기만 하는데 ... 자식들은 싹 다 하나만 남겨야되네
+                    try await APIService.emptyOutPlanWithAllChild(
+                        currentPlan: currentPlan,
+                        currentLayerIndex: layerIndex,
+                        &projectMap,
+                        projectID: projectID
+                    )
+                    let emptyData = [
+                        "periods": nil,
+                        "planTypeID": nil
+                    ] as [String: Any?]
+                    try await FirestoreService.updateDocumentData(projectID, .plans, planID, emptyData as [String: Any])
+                }
             } else {
-                /// 하위 레이어는 남겨두는 경우 == periods만 삭제
-                try await planCollectionPath(projectID).document(planID).updateData(["periods": [:]])
+                /// 하위 레이어는 남겨두는 경우 == periods, type만 삭제
+                let emptyData = ["periods": nil, "planTypeID": nil] as [String: Any?]
+                try await FirestoreService.updateDocumentData(projectID, .plans, planID, emptyData as [String: Any])
             }
+            try await FirestoreService.projectCollectionPath.document(projectID).updateData(["map": projectMap])
             return projectMap
         },
         updatePlan: { planID, planTypeID, projectID in
             /// planTypeID를 업데이트하는 updatePlan
             /// periods를 업데이트하는 updatePlan도 필요함
-            try await planCollectionPath(projectID).document(planID).updateData(["planTypeID": planTypeID])
-            let result = try await planCollectionPath(projectID).document(planID).getDocument(as: Plan.self)
-            return result
+            try await FirestoreService.updateDocumentData(projectID, .plans, planID, ["planTypeID": planTypeID])
+            return try await FirestoreService.getDocument(projectID, .plans, planID, Plan.self) as! Plan
         },
         readAllPlans: { projectID in
-            let plans = try await planCollectionPath(projectID).getDocuments().documents.map { try $0.data(as: Plan.self) }
+            let plans = try await FirestoreService.getDocuments(projectID, .plans, Plan.self) as! [Plan]
             var result = [String: Plan]()
             for plan in plans {
                 result[plan.id] = plan
@@ -370,25 +309,25 @@ extension APIService {
             return result
         },
         createLane: { layerIndex, laneIndex, createOnTop, planID, projectID in
-            var projectMap = try await projectCollectionPath.document(projectID).getDocument(as: Project.self).map
+            var projectMap = try await FirestoreService.projectCollectionPath.document(projectID).getDocument(as: Project.self).map
             let maximumDepth = projectMap.count
             var targetPlanID = planID
             /// 최하위 레이어까지 해당 위치에 새 레인 생성
             for currentLayerIndex in layerIndex..<maximumDepth {
-                let planData = try await planCollectionPath(projectID).document(targetPlanID).getDocument(as: Plan.self)
+                let planData = try await FirestoreService.getDocument(projectID, .plans, targetPlanID, Plan.self) as! Plan
                 if var parentLaneID = planData.parentLaneID {
-                    let parentLane = try await laneCollectionPath(projectID).document(parentLaneID).getDocument(as: Lane.self)
+                    let parentLane = try await FirestoreService.getDocument(projectID, .lanes, parentLaneID, Lane.self) as! Lane
                     if var childIDsInLane = parentLane.childIDs {
                         let newPlanID = UUID().uuidString
-                        let newLaneID = try laneCollectionPath(projectID).document().documentID
-                        try await laneCollectionPath(projectID).document(newLaneID).setData(["id": newLaneID, "ownerID": newPlanID])
-                        try await planCollectionPath(projectID).document(newPlanID).setData(["id": newPlanID, "periods": [], "laneIDs": [newLaneID]])
+                        let newLaneID = try FirestoreService.getNewDocumentID(projectID, .lanes)
+                        try await FirestoreService.setDocumentData(projectID, .lanes, newLaneID, ["id": newLaneID, "ownerID": newPlanID])
+                        try await FirestoreService.setDocumentData(projectID, .plans, newPlanID, ["id": newPlanID, "periods": [], "laneIDs": [newLaneID]])
                         let newChildIndex = childIDsInLane.firstIndex(of: targetPlanID)! + (createOnTop ? 0 : 1)
                         childIDsInLane.insert(
                             newPlanID,
                             at: newChildIndex
                         )
-                        try await laneCollectionPath(projectID).document(parentLaneID).updateData(["childIDs": childIDsInLane])
+                        try await FirestoreService.updateDocumentData(projectID, .lanes, parentLaneID, ["childIDs": childIDsInLane])
                         /// update project map
                         projectMap[currentLayerIndex.description]?.insert(targetPlanID, at: newChildIndex)
                         /// 다음 레이어에서 lane을 추가해줄 child plan으로 값 업데이트
@@ -400,7 +339,7 @@ extension APIService {
                     projectMap[layerIndex.description] = []
                     for dummy in 0...laneIndex {
                         let dummyPlan = Plan(id: UUID().uuidString, periods: [:], laneIDs: [])
-                        try await planCollectionPath(projectID).document(dummyPlan.id).setData(["id": dummyPlan.id, "periods": [], "laneIDs": []])
+                        try await FirestoreService.setDocumentData(projectID, .plans, dummyPlan.id, ["id": dummyPlan.id, "periods": [], "laneIDs": []])
                         projectMap[layerIndex.description]!.append(dummyPlan.id)
                     }
                 }
@@ -413,7 +352,7 @@ extension APIService {
         },
         createLayer: { layerIndex, projectID in
             /// projectMap에 새 레이어를 추가
-            var projectMap = try await projectCollectionPath.document(projectID).getDocument(as: Project.self).map
+            var projectMap = try await FirestoreService.projectCollectionPath.document(projectID).getDocument(as: Project.self).map
             let currentProjectMapLayerSize = projectMap.count
             
             if (currentProjectMapLayerSize - 1) < layerIndex {
@@ -432,15 +371,15 @@ extension APIService {
                         if let previousFirstLayer = projectMap["0"] {
                             for planID in previousFirstLayer {
                                 /// 기존 0번째 레이어에 있던 플랜의 수만큼 parent로 쓸 플랜을 생성하고 연결
-                                let newLaneID = try laneCollectionPath(projectID).document().documentID
+                                let newLaneID = try FirestoreService.getNewDocumentID(projectID, .lanes)
                                 let newPlan = Plan(id: UUID().uuidString, periods: [:], laneIDs: [newLaneID])
                                 let newLane = Lane(id: newLaneID, childIDs: [planID], ownerID: newPlan.id)
                                 newFirstLayer.append(newPlan.id)
-                                try await planCollectionPath(projectID).document(newPlan.id).setData(["id": newPlan.id, "periods": [], "laneIDs": []])
-                                try await laneCollectionPath(projectID).document(newLaneID).setData(["id": newLaneID, "ownerID": newPlan.id])
+                                try await FirestoreService.setDocumentData(projectID, .plans, newPlan.id, ["id": newPlan.id, "periods": [], "laneIDs": []])
+                                try await FirestoreService.setDocumentData(projectID, .lanes, newLaneID, ["id": newLaneID, "ownerID": newPlan.id])
                             }
                         }
-                        for currentLayerIndex in stride(from: projectMap.count-1, through: 0, by: -1) {
+                        for currentLayerIndex in stride(from: projectMap.count-1, through: -1, by: -1) {
                             projectMap["\(currentLayerIndex + 1)"] = projectMap["\(currentLayerIndex)"]
                         }
                         projectMap["0"] = newFirstLayer
@@ -453,7 +392,7 @@ extension APIService {
                     
                     /// 생성된 레이어에, layerIndex(상위레이어)에 위치한 plan이
                     for planIDInUpperLayer in projectMap[layerIndex.description]! {
-                        let upperPlan = try await planCollectionPath(projectID).document(planIDInUpperLayer).getDocument(as: Plan.self)
+                        let upperPlan = try await FirestoreService.getDocument(projectID, .plans, planIDInUpperLayer, Plan.self) as! Plan
                         var newUpperPlansLanes = []
                         /// 가지는 lane만큼
                         for laneIndex in 0..<upperPlan.laneIDs.count {
@@ -464,21 +403,88 @@ extension APIService {
                             
                             /// upper plan의 lane을 새로 생성된 빈 플랜으로 옮겨주고,
                             newPlan.laneIDs.insert(upperPlan.laneIDs[laneIndex], at: laneIndex)
-                            try await planCollectionPath(projectID).document(newPlan.id).setData(["id": newPlan.id, "periods": [], "laneIDs": newPlan.laneIDs as Any])
+                            try await FirestoreService.setDocumentData(projectID, .plans, newPlan.id, ["id": newPlan.id, "periods": [], "laneIDs": newPlan.laneIDs])
                             
                             /// 그 child plan의 lane들이 가리키는 planID를 생성된 plan으로 변경
                             for laneID in upperPlan.laneIDs {
-                                try await laneCollectionPath(projectID).document(laneID).updateData(["planIDs": newPlan.id])
+                                try await FirestoreService.updateDocumentData(projectID, .lanes, laneID, ["planIDs": newPlan.id])
                             }
                         }
                         /// 부모 플랜이 가지는 laneIDs도 업데이트
-                        try await planCollectionPath(projectID).document(upperPlan.id).updateData(["laneIDs": newUpperPlansLanes])
+                        try await FirestoreService.updateDocumentData(projectID, .plans, upperPlan.id, ["laneIDs": newUpperPlansLanes])
                     }
                 }
             }
             /// 수정된 map을 다시 해당 프로젝트에 업데이트
-            try await projectCollectionPath.document(projectID).updateData(["map": projectMap])
+            try await FirestoreService.projectCollectionPath.document(projectID).updateData(["map": projectMap])
             return projectMap
         }
     )
+    
+    /// 비우기만
+    static func emptyOutPlanWithAllChild(
+        currentPlan: Plan,
+        currentLayerIndex: Int,
+        _ projectMap: inout [String: [String]],
+        projectID: String
+    ) async throws {
+        for laneID in currentPlan.laneIDs {
+            /// plan이 가진 lane들에 속한 plan을 먼저 삭제, 재귀적으로 최하위까지 비움
+            let currentLane = try await FirestoreService.getDocument(projectID, .lanes, laneID, Lane.self) as! Lane
+            if let childIDs = currentLane.childIDs {
+                for planID in childIDs {
+                    let nextPlan = try await FirestoreService.getDocument(projectID, .plans, planID, Plan.self) as! Plan
+                    try await emptyOutPlanWithAllChild(
+                        currentPlan: nextPlan,
+                        currentLayerIndex: currentLayerIndex + 1,
+                        &projectMap,
+                        projectID: projectID
+                    )
+                    if laneID == currentPlan.laneIDs.first,
+                       planID == childIDs.first {
+                        let emptyData = [
+                            "periods": nil,
+                            "planTypeID": nil
+                        ] as [String: Any?]
+                        try await FirestoreService.updateDocumentData(projectID, .plans, planID, emptyData as [String: Any])
+                    } else {
+                        try await FirestoreService.deleteDocument(projectID, .plans, planID)
+                        projectMap["\(currentLayerIndex)"]!.remove(at: projectMap["\(currentLayerIndex)"]!.firstIndex(of: currentPlan.id)!)
+                    }
+                }
+            }
+            /// 하나의 lane(첫 lane)은 제외하고 나머지 lane들은 삭제
+            if laneID == currentPlan.laneIDs.first! { continue }
+            try await FirestoreService.deleteDocument(projectID, .lanes, laneID)
+        }
+    }
+    
+    /// 싹 삭제
+    static func deletePlanWithAllChild(
+        currentPlan: Plan,
+        currentLayerIndex: Int,
+        _ projectMap: inout [String: [String]],
+        projectID: String
+    ) async throws {
+        for laneID in currentPlan.laneIDs {
+            /// plan이 가진 lane들에 속한 plan을 먼저 삭제, 재귀적으로 최하위까지 삭제
+            let currentLane = try await FirestoreService.getDocument(projectID, .lanes, laneID, Lane.self) as! Lane
+            if let childIDs = currentLane.childIDs {
+                for planID in childIDs {
+                    let nextPlan = try await FirestoreService.getDocument(projectID, .plans, planID, Plan.self) as! Plan
+                    try await deletePlanWithAllChild(
+                        currentPlan: nextPlan,
+                        currentLayerIndex: currentLayerIndex + 1,
+                        &projectMap,
+                        projectID: projectID
+                    )
+                    try await FirestoreService.deleteDocument(projectID, .plans, planID)
+                    projectMap["\(currentLayerIndex)"]!.remove(at: projectMap["\(currentLayerIndex)"]!.firstIndex(of: currentPlan.id)!)
+                }
+            }
+            /// 하나의 lane(첫 lane)은 제외하고 나머지 lane들은 삭제
+            if laneID == currentPlan.laneIDs.first { continue }
+            try await FirestoreService.deleteDocument(projectID, .lanes, laneID)
+        }
+    }
 }

--- a/gridy/Sources/Network/FirestoreService.swift
+++ b/gridy/Sources/Network/FirestoreService.swift
@@ -1,0 +1,18 @@
+//
+//  FirestoreService.swift
+//  gridy
+//
+//  Created by SY AN on 10/30/23.
+//
+
+import SwiftUI
+
+struct FirestoreService: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    FirestoreService()
+}

--- a/gridy/Sources/Presentations/Authentication/AuthenticationView.swift
+++ b/gridy/Sources/Presentations/Authentication/AuthenticationView.swift
@@ -12,7 +12,7 @@ struct AuthenticationView: View {
     
     let store = Store(initialState: Authentication.State()) {
         Authentication()
-//            ._printChanges()
+            ._printChanges()
     }
     
     var body: some View {

--- a/gridy/Sources/Presentations/Authentication/AuthenticationView.swift
+++ b/gridy/Sources/Presentations/Authentication/AuthenticationView.swift
@@ -12,7 +12,7 @@ struct AuthenticationView: View {
     
     let store = Store(initialState: Authentication.State()) {
         Authentication()
-            ._printChanges()
+//            ._printChanges()
     }
     
     var body: some View {

--- a/gridy/Sources/Presentations/PlanBoard/PlanBoard.swift
+++ b/gridy/Sources/Presentations/PlanBoard/PlanBoard.swift
@@ -92,7 +92,7 @@ struct PlanBoard: Reducer {
         case fetchAllPlanTypesResponse(TaskResult<[PlanType]>)
         
         // MARK: - plan
-        case createPlan(layer: Int, target: Plan, startDate: Date?, endDate: Date?)
+        case createPlan(layer: Int, row: Int, target: Plan, startDate: Date?, endDate: Date?)
         case createPlanResponse(TaskResult<[String: [String]]>)
         case updatePlan(planID: String, planTypeID: String)
         case fetchAllPlans
@@ -206,7 +206,7 @@ struct PlanBoard: Reducer {
                 return .none
                 
                 // MARK: - plan
-            case let .createPlan(layer, target, startDate, endDate):
+            case let .createPlan(layer, row, target, startDate, endDate):
                 // TODO: - 나중에 삭제해도 되는 코드인듯! 헨리 확인 부탁해요~
                 let projectID = state.rootProject.id
                 
@@ -233,7 +233,7 @@ struct PlanBoard: Reducer {
                 return .run { send in
                     await send(.createPlanResponse(
                         TaskResult {
-                            try await apiService.createPlan(planToBeCreated, layer, projectID)
+                            try await apiService.createPlan(planToBeCreated, layer, row, projectID)
                         }
                     ), animation: .easeIn)
                 }

--- a/gridy/Sources/Presentations/PlanBoard/PlanBoard.swift
+++ b/gridy/Sources/Presentations/PlanBoard/PlanBoard.swift
@@ -244,7 +244,7 @@ struct PlanBoard: Reducer {
                 
             case let .updatePlan(planID, planTypeID):
                 let projectID = state.rootProject.id
-                return .run { send in
+                return .run { _ in
                     try await apiService.updatePlan(planID, planTypeID, projectID)
                 }
                 

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/LineArea/LineAreaView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/LineArea/LineAreaView.swift
@@ -47,6 +47,7 @@ struct LineAreaView: View {
                                 viewStore.send(.createPlan(
                                     // TODO: - Need arguments #1, #2
                                     layer: 1,
+                                    row: 0,
                                     target: Plan(
                                         id: "",
                                         parentLaneID: nil, // TODO: - root layer가 아니라면 parentLaneID 필요

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
@@ -126,8 +126,13 @@ struct ListAreaView: View {
                                     // MARK: - ListItemSection
                                     /// 기존에 맵이 들고있는 layer들을 먼저 뿌려줌
                                     if viewStore.map.count > 0 {
-                                        ForEach(0..<viewStore.map[String(layer)]!.count) { _ in
-                                            ListItemView(store: store)
+                                        ForEach(0..<viewStore.map[String(layer)]!.count) { row in
+                                            Color.clear.onAppear {
+                                                print(viewStore.map)
+                                                print("# at layer: \(layer)")
+                                                print(viewStore.map[String(layer)]!.count)
+                                            }
+                                            ListItemView(store: store, layerIndex: layer, rowIndex: row)
                                         }
                                     }
                                     
@@ -135,7 +140,7 @@ struct ListAreaView: View {
                                     // TODO: showingRows->maxRow 변화할 때마다 업데이트
                                     /// 그 아래에 빈 listItemView를 뿌려주어서 Plan 생성이 가능하도록 함
                                     ForEach(0..<viewStore.showingRows) { _ in
-                                        ListItemEmptyView(store: store)
+                                        ListItemEmptyView(store: store, layerIndex: layer)
                                     }
                                 }
                                 .frame(width: viewStore.listColumnWidth[viewStore.showingLayers.count-1][forIndex])

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
@@ -70,21 +70,9 @@ struct ListAreaView: View {
                             ForEach(Array(viewStore.showingLayers.indices), id: \.self) { forIndex in
                                 let layer = viewStore.showingLayers[forIndex]
                                 let layerArray = viewStore.map[String(layer)]!
-                                var layerSize = layerArray.count
-                                
-                                var height = 0
-                                var numOfChild = 0
-                                /// 내 leaf의 lane 수를 찾아야 함
-                                ForEach(0..<viewStore.showingLayers.count, id: \.self) { index in
-                                    let layerIndex = layer + index
-                                    Color.clear.onAppear { print(layerIndex) }
-                                }
+                                let layerSize = layerArray.count
                                 
                                 VStack(alignment: .leading, spacing: 0) {
-                                    
-                                    var showingAtFirst = (viewStore.showingLayers.count == 3 && forIndex == 0)
-                                    
-                                    /// 기존에 맵이 들고있는 layer들을 먼저 뿌려줌
                                     if viewStore.map.count > 0 {
                                         ForEach(Array(viewStore.map[String(layer)]!.indices), id: \.self) { row in
                                             ListItemView(store: store, layerIndex: layer, rowIndex: row)

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
@@ -66,29 +66,27 @@ struct ListAreaView: View {
                             )
                     } else {
                         // MARK: - ListArea Contents
-                        VStack(spacing: 0) {
-                            HStack(alignment: .top, spacing: 2) {
-                                ForEach(Array(zip(viewStore.showingLayers.indices, viewStore.showingLayers)), id: \.0) { forIndex, layerIndex in
-                                    VStack(alignment: .leading, spacing: 0) {
-                                        let layer = viewStore.showingLayers[forIndex]
-                                        let showingAtFirst = (viewStore.showingLayers.count == 3 && forIndex == 0)
-                                        
-                                        /// 기존에 맵이 들고있는 layer들을 먼저 뿌려줌
-                                        if viewStore.map.count > 0 {
-                                            ForEach(0..<viewStore.map[String(layer)]!.count) { row in
-                                                ListItemView(store: store, layerIndex: layer, rowIndex: row)
-                                            }
-                                        }
-                                        
-                                        // TODO: map이 가진 lane수가 viewStore.showingRows보다 크면 showingRows를 lane개수 + showingRows로 업데이트
-                                        // TODO: showingRows->maxRow 변화할 때마다 업데이트
-                                        /// 그 아래에 빈 listItemView를 뿌려주어서 Plan 생성이 가능하도록 함
-                                        ForEach(0..<viewStore.showingRows) { _ in
-                                            ListItemEmptyView(store: store, layerIndex: layer)
+                        HStack(alignment: .top, spacing: 2) {
+                            ForEach(Array(viewStore.showingLayers.indices), id: \.self) { forIndex in
+                                VStack(alignment: .leading, spacing: 0) {
+                                    let layer = viewStore.showingLayers[forIndex]
+                                    let showingAtFirst = (viewStore.showingLayers.count == 3 && forIndex == 0)
+                                    
+                                    /// 기존에 맵이 들고있는 layer들을 먼저 뿌려줌
+                                    if viewStore.map.count > 0 {
+                                        ForEach(Array(viewStore.map[String(layer)]!.indices), id: \.self) { row in
+                                            ListItemView(store: store, layerIndex: layer, rowIndex: row)
                                         }
                                     }
-                                    .frame(width: viewStore.listColumnWidth[viewStore.showingLayers.count]![forIndex])
+                                    
+                                    // TODO: map이 가진 lane수가 viewStore.showingRows보다 크면 showingRows를 lane개수 + showingRows로 업데이트
+                                    // TODO: showingRows->maxRow 변화할 때마다 업데이트
+                                    /// 그 아래에 빈 listItemView를 뿌려주어서 Plan 생성이 가능하도록 함
+                                    ForEach(0..<viewStore.showingRows) { _ in
+                                        ListItemEmptyView(store: store, layerIndex: layer)
+                                    }
                                 }
+                                .frame(width: viewStore.listColumnWidth[viewStore.showingLayers.count]![forIndex])
                             }
                         }
                     }

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
@@ -70,7 +70,8 @@ struct ListAreaView: View {
                             ForEach(Array(viewStore.showingLayers.indices), id: \.self) { forIndex in
                                 VStack(alignment: .leading, spacing: 0) {
                                     let layer = viewStore.showingLayers[forIndex]
-                                    let showingAtFirst = (viewStore.showingLayers.count == 3 && forIndex == 0)
+                                    var layerSize = viewStore.map[String(layer)]!.count
+                                    var showingAtFirst = (viewStore.showingLayers.count == 3 && forIndex == 0)
                                     
                                     /// 기존에 맵이 들고있는 layer들을 먼저 뿌려줌
                                     if viewStore.map.count > 0 {
@@ -82,8 +83,8 @@ struct ListAreaView: View {
                                     // TODO: map이 가진 lane수가 viewStore.showingRows보다 크면 showingRows를 lane개수 + showingRows로 업데이트
                                     // TODO: showingRows->maxRow 변화할 때마다 업데이트
                                     /// 그 아래에 빈 listItemView를 뿌려주어서 Plan 생성이 가능하도록 함
-                                    ForEach(0..<viewStore.showingRows) { _ in
-                                        ListItemEmptyView(store: store, layerIndex: layer)
+                                    ForEach(layerSize..<viewStore.showingRows, id: \.self) { row in
+                                        ListItemEmptyView(store: store, layerIndex: layer, rowIndex: row)
                                     }
                                 }
                                 .frame(width: viewStore.listColumnWidth[viewStore.showingLayers.count]![forIndex])

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListAreaView.swift
@@ -68,9 +68,20 @@ struct ListAreaView: View {
                         // MARK: - ListArea Contents
                         HStack(alignment: .top, spacing: 2) {
                             ForEach(Array(viewStore.showingLayers.indices), id: \.self) { forIndex in
+                                let layer = viewStore.showingLayers[forIndex]
+                                let layerArray = viewStore.map[String(layer)]!
+                                var layerSize = layerArray.count
+                                
+                                var height = 0
+                                var numOfChild = 0
+                                /// 내 leaf의 lane 수를 찾아야 함
+                                ForEach(0..<viewStore.showingLayers.count, id: \.self) { index in
+                                    let layerIndex = layer + index
+                                    Color.clear.onAppear { print(layerIndex) }
+                                }
+                                
                                 VStack(alignment: .leading, spacing: 0) {
-                                    let layer = viewStore.showingLayers[forIndex]
-                                    var layerSize = viewStore.map[String(layer)]!.count
+                                    
                                     var showingAtFirst = (viewStore.showingLayers.count == 3 && forIndex == 0)
                                     
                                     /// 기존에 맵이 들고있는 layer들을 먼저 뿌려줌

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
@@ -22,6 +22,8 @@ struct ListItemEmptyView: View {
     @State var editingText =  ""
     @State var prevText = ""
     
+    var layerIndex: Int
+    
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             ZStack {
@@ -57,20 +59,24 @@ struct ListItemEmptyView: View {
                 // MARK: - 한 번 클릭 된 상태.
                 /// 호버링 상태를 추적하지 않는다. 흰 배경에 보더만 파란 상태. 더블 클릭이 가능하다.
                 if isSelected {
-                    Rectangle()
-                        .strokeBorder(Color.blue)
-                        .overlay(
-                            Text(editingText)
-                                .lineLimit(2)
-                                .font(.custom("Pretendard-Regular", size: fontSize))
-                                .padding(.horizontal, 8)
-                        )
-                        .onTapGesture(count: 2) {
-                            isSelected = false
-                            isEditing = true
-                            isTextFieldFocused = true
-                            prevText = editingText
-                        }
+                    ZStack {
+                        Rectangle()
+                            .foregroundStyle(Color.white)
+                        Rectangle()
+                            .strokeBorder(Color.blue)
+                            .overlay(
+                                Text(editingText)
+                                    .lineLimit(2)
+                                    .font(.custom("Pretendard-Regular", size: fontSize))
+                                    .padding(.horizontal, 8)
+                            )
+                    }
+                    .onTapGesture(count: 2) {
+                        isSelected = false
+                        isEditing = true
+                        isTextFieldFocused = true
+                        prevText = editingText
+                    }
                 }
                 
                 // MARK: - 더블 클릭 된 상태.
@@ -82,9 +88,21 @@ struct ListItemEmptyView: View {
                             // TODO: Plan type 수정 -> 생성하는 flow
                             TextField("Editing", text: $editingText, axis: .vertical )
                                 .onSubmit {
+                                    viewStore.send(.createPlan(
+                                        layer: layerIndex,
+                                        target: Plan(
+                                            id: "",
+                                            // TODO: - root layer가 아니라면 parentLaneID 필요
+//                                            parentLaneID: layerIndex == 0 ? nil : nil,
+                                            parentLaneID: nil,
+                                            periods: [:],
+                                            laneIDs: []
+                                        ),
+                                        startDate: nil,
+                                        endDate: nil
+                                    ))
                                     isEditing = false
                                     isTextFieldFocused = false
-                                    // TODO: CreatePlan
                                 }
                                 .multilineTextAlignment(.center)
                                 .font(.custom("Pretendard-Medium", size: fontSize))
@@ -110,6 +128,7 @@ struct ListItemEmptyView: View {
     ListItemEmptyView(
         store: Store(initialState: PlanBoard.State(rootProject: Project.mock, map: Project.mock.map)) {
             PlanBoard()
-        }
+        },
+        layerIndex: 0
     )
 }

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
@@ -23,6 +23,7 @@ struct ListItemEmptyView: View {
     @State var prevText = ""
     
     var layerIndex: Int
+    var rowIndex: Int
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -33,7 +34,8 @@ struct ListItemEmptyView: View {
                     Rectangle()
                         .foregroundStyle(isHovering ? Color.gray.opacity(0.2) : Color.clear)
                         .overlay(
-                            Text(editingText)
+                            // TODO: - editingText로 변경
+                            Text("\(rowIndex)")
                                 .lineLimit(2)
                                 .font(.custom("Pretendard-Regular", size: fontSize))
                                 .padding(.horizontal, 8)
@@ -88,22 +90,11 @@ struct ListItemEmptyView: View {
                             // TODO: Plan type 수정 -> 생성하는 flow
                             TextField("Editing", text: $editingText, axis: .vertical )
                                 .onSubmit {
-//                                    let myIndex = viewStore.map[String(layerIndex)]!.count
-//                                    print(layerIndex)
-//                                    let isFirstLayer = layerIndex == 0
-//                                    let prevLayerCount = isFirstLayer ? 0 : viewStore.map[String(layerIndex-1)]!.count
-//                                    let needToCreateLane = prevLayerCount - 1 < myIndex
-//                                    
-//                                    let parentLaneID = isFirstLayer ? nil : needToCreateLane ? nil : viewStore.existingAllPlans[viewStore.map[String(layerIndex-1)]![myIndex]]!.laneIDs[0]
-//                                    print(viewStore.map)
-//                                    print(parentLaneID)
-                                    
-                                    viewStore.send(.createPlan(
+                                 viewStore.send(.createPlan(
                                         layer: layerIndex,
+                                        row: rowIndex,
                                         target: Plan(
                                             id: "",
-                                            // TODO: - root layer가 아니라면 parentLaneID 필요
-//                                            parentLaneID: layerIndex == 0 ? nil : nil,
                                             parentLaneID: nil,
                                             periods: [:],
                                             laneIDs: []
@@ -140,6 +131,7 @@ struct ListItemEmptyView: View {
         store: Store(initialState: PlanBoard.State(rootProject: Project.mock, map: Project.mock.map)) {
             PlanBoard()
         },
-        layerIndex: 0
+        layerIndex: 0,
+        rowIndex: 0
     )
 }

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
@@ -88,6 +88,16 @@ struct ListItemEmptyView: View {
                             // TODO: Plan type 수정 -> 생성하는 flow
                             TextField("Editing", text: $editingText, axis: .vertical )
                                 .onSubmit {
+//                                    let myIndex = viewStore.map[String(layerIndex)]!.count
+//                                    print(layerIndex)
+//                                    let isFirstLayer = layerIndex == 0
+//                                    let prevLayerCount = isFirstLayer ? 0 : viewStore.map[String(layerIndex-1)]!.count
+//                                    let needToCreateLane = prevLayerCount - 1 < myIndex
+//                                    
+//                                    let parentLaneID = isFirstLayer ? nil : needToCreateLane ? nil : viewStore.existingAllPlans[viewStore.map[String(layerIndex-1)]![myIndex]]!.laneIDs[0]
+//                                    print(viewStore.map)
+//                                    print(parentLaneID)
+                                    
                                     viewStore.send(.createPlan(
                                         layer: layerIndex,
                                         target: Plan(

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
@@ -103,6 +103,7 @@ struct ListItemEmptyView: View {
                                     ))
                                     isEditing = false
                                     isTextFieldFocused = false
+                                    editingText = ""
                                 }
                                 .multilineTextAlignment(.center)
                                 .font(.custom("Pretendard-Medium", size: fontSize))

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemEmptyView.swift
@@ -117,6 +117,7 @@ struct ListItemEmptyView: View {
                                     editingText = prevText
                                     isEditing = false
                                     isTextFieldFocused = false
+                                    isHovering = false
                                 }
                         }
                 }

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
@@ -22,6 +22,9 @@ struct ListItemView: View {
     @State var editingText =  ""
     @State var prevText = ""
     
+    var layerIndex: Int
+    var rowIndex: Int
+    
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             // TODO: - 실제 Plan 받아오기
@@ -32,7 +35,7 @@ struct ListItemView: View {
                     Rectangle()
                         .foregroundStyle(isHovering ? Color.gray.opacity(0.2) : Color.clear)
                         .overlay(
-                            Text(editingText)
+                            Text(viewStore.map[String(layerIndex)]![rowIndex])
                                 .lineLimit(2)
                                 .font(.custom("Pretendard-Regular", size: fontSize))
                                 .padding(.horizontal, 8)
@@ -111,6 +114,8 @@ struct ListItemView: View {
     ListItemView(
         store: Store(initialState: PlanBoard.State(rootProject: Project.mock, map: Project.mock.map)) {
             PlanBoard()
-        }
+        },
+        layerIndex: 0,
+        rowIndex: 0
     )
 }

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
@@ -35,10 +35,18 @@ struct ListItemView: View {
                     Rectangle()
                         .foregroundStyle(isHovering ? Color.gray.opacity(0.2) : Color.clear)
                         .overlay(
-                            Text(viewStore.map[String(layerIndex)]![rowIndex])
-                                .lineLimit(2)
-                                .font(.custom("Pretendard-Regular", size: fontSize))
-                                .padding(.horizontal, 8)
+                            Text(editingText)
+                                .onAppear {
+                                    if let plan = viewStore.existingAllPlans[viewStore.map[String(layerIndex)]![rowIndex]],
+                                       let planTypeID = plan.planTypeID,
+                                       let planType = viewStore.existingPlanTypes[planTypeID] {
+                                        let title = planType.title
+                                        editingText = title
+                                    } else {
+                                        // TODO: - 옵셔널 분기 없어야함. map에 있는 ID로 existingAllPlans에 접근하면 무조건 있어야 함.
+                                        editingText = viewStore.map[String(layerIndex)]![rowIndex]
+                                    }
+                                }
                         )
                         .onHover { phase in
                             if !isSelected && !isEditing {

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
@@ -88,13 +88,13 @@ struct ListItemView: View {
                     }
                     .contextMenu {
                         Button {
-                            
+                            // TODO: - createPlan, 인자 true
                         } label: {
                             Text("Add a lane above")
                         }
                         
                         Button {
-                            
+                            // TODO: - createPlan, 인자 false
                         } label: {
                             Text("Add a lane below")
                         }

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
@@ -27,7 +27,6 @@ struct ListItemView: View {
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
-            // TODO: - 실제 Plan 받아오기
             ZStack {
                 // MARK: - 초기 상태.
                 /// 빈 Text를 보여준다.  클릭, 더블클릭이 가능하고 호버링이 되면 배경이 회색으로 변경된다.

--- a/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
+++ b/gridy/Sources/Presentations/PlanBoard/TimelineLayout/ListArea/ListItemView.swift
@@ -69,20 +69,37 @@ struct ListItemView: View {
                 // MARK: - 한 번 클릭 된 상태.
                 /// 호버링 상태를 추적하지 않는다. 흰 배경에 보더만 파란 상태. 더블 클릭이 가능하다.
                 if isSelected {
-                    Rectangle()
-                        .strokeBorder(Color.blue)
-                        .overlay(
-                            Text(editingText)
-                                .lineLimit(2)
-                                .font(.custom("Pretendard-Regular", size: fontSize))
-                                .padding(.horizontal, 8)
-                        )
-                        .onTapGesture(count: 2) {
-                            isSelected = false
-                            isEditing = true
-                            isTextFieldFocused = true
-                            prevText = editingText
+                    ZStack {
+                        Rectangle()
+                            .foregroundStyle(Color.white)
+                        Rectangle()
+                            .strokeBorder(Color.blue)
+                            .overlay(
+                                Text(editingText)
+                                    .lineLimit(2)
+                                    .font(.custom("Pretendard-Regular", size: fontSize))
+                                    .padding(.horizontal, 8)
+                            )
+                    }
+                    .onTapGesture(count: 2) {
+                        isSelected = false
+                        isEditing = true
+                        isTextFieldFocused = true
+                        prevText = editingText
+                    }
+                    .contextMenu {
+                        Button {
+                            
+                        } label: {
+                            Text("Add a lane above")
                         }
+                        
+                        Button {
+                            
+                        } label: {
+                            Text("Add a lane below")
+                        }
+                    }
                 }
                 
                 // MARK: - 더블 클릭 된 상태.

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardSideView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardSideView.swift
@@ -42,7 +42,7 @@ struct ProjectBoardSideView: View {
                         .padding(.vertical)
                     
                     Button {
-                        //TODO: New Folder Button
+                        // TODO: - New Folder Button
                     } label: {
                         RoundedRectangle(cornerRadius: 12)
                             .foregroundStyle(.blue)

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectSideItemView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectSideItemView.swift
@@ -13,7 +13,7 @@ struct ProjectSideItemView: View {
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
-            GeometryReader { geometry in
+            GeometryReader { _ in
                 Rectangle()
                     .foregroundStyle(.gray.opacity(0.1))
                     .overlay {


### PR DESCRIPTION
# Description
listArea에서 createPlan 붙였습니다.

1. listArea에서 텍스트를 치고 엔터를 누르면 생성된 플랜과 더미 플랜의 "ID"를 확인 가능합니다.
2. 배열 윗 부분은 현존하는 map의 planID 리스트, 배열 아랫 부분은 empty 리스트로 넣어놨습니다.

저는 다음에 text와 함께 create 하고 (lane 추가 하는 기능 + Height계산 로직으로 넘어갑니다)

# Screenshots & Demo

https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-Ampersand/assets/102544840/dbc6d6d3-82a9-4bd1-9fa3-5f99ac19014d


# To Reviewers 🤲
- [ ] 절대 layer 추가를 하지 마시오 @dayo2n 레이어 추가했을 때에 동일한 dummy 가 생겨야 합니다.
- [ ] 이후에 제나의 createPlanType코드를 이용하여 입력한 텍스트를 서버에 올릴 수 있도록 로직을 수정할 예정입니다.
- [ ] 상당한 시간이 소요될 수 있기에 인내심을 가지고 createPlan의 결과를 기다려주시길 부탁드리는 바입니다. 