### PR TITLE
[feat][#86] WindowButton과 TabBarView 맞추기

### DIFF
--- a/gridy.xcodeproj/project.pbxproj
+++ b/gridy.xcodeproj/project.pbxproj
@@ -58,7 +58,7 @@
 		ADCBA9F42AF58603000BBD1C /* ImageUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCBA9F32AF58603000BBD1C /* ImageUploader.swift */; };
 		ADCBA9F62AFA9B36000BBD1C /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCBA9F52AFA9B36000BBD1C /* Notice.swift */; };
 		ADCBA9F82AFA9FAA000BBD1C /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADCBA9F72AFA9FAA000BBD1C /* Feedback.swift */; };
-		D167A0742AF6192400B70E5E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D167A0732AF6192400B70E5E /* GoogleService-Info.plist */; };
+		D107212A2B0D0192006B7991 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D10721292B0D0192006B7991 /* GoogleService-Info.plist */; };
 		D17800692AF35989002984CF /* PlanBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17800682AF35989002984CF /* PlanBoardView.swift */; };
 		D178006B2AF36952002984CF /* TopToolBarArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = D178006A2AF36952002984CF /* TopToolBarArea.swift */; };
 		EE780DB72B023686005E761F /* EditPlanBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE780DB62B023686005E761F /* EditPlanBoardView.swift */; };
@@ -119,7 +119,7 @@
 		ADCBA9F32AF58603000BBD1C /* ImageUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploader.swift; sourceTree = "<group>"; };
 		ADCBA9F52AFA9B36000BBD1C /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
 		ADCBA9F72AFA9FAA000BBD1C /* Feedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
-		D167A0732AF6192400B70E5E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		D10721292B0D0192006B7991 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		D17800682AF35989002984CF /* PlanBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanBoardView.swift; sourceTree = "<group>"; };
 		D178006A2AF36952002984CF /* TopToolBarArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopToolBarArea.swift; sourceTree = "<group>"; };
 		EE780DB62B023686005E761F /* EditPlanBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPlanBoardView.swift; sourceTree = "<group>"; };
@@ -220,7 +220,7 @@
 		AD8ECB8C2ABC7CA10040A0B8 /* gridy */ = {
 			isa = PBXGroup;
 			children = (
-				D167A0732AF6192400B70E5E /* GoogleService-Info.plist */,
+				D10721292B0D0192006B7991 /* GoogleService-Info.plist */,
 				8A3FF43B2AF93E2A002919DB /* Info.plist */,
 				AD8ECB9D2ABC7CC00040A0B8 /* Sources */,
 				AD8ECB9E2ABC7CC80040A0B8 /* Resources */,
@@ -426,13 +426,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A3FF43C2AF93E2B002919DB /* Info.plist in Resources */,
+				D107212A2B0D0192006B7991 /* GoogleService-Info.plist in Resources */,
 				AD8ECB922ABC7CA20040A0B8 /* Assets.xcassets in Resources */,
 				8A5162482AC403BB00EEB1B4 /* Lexend-VariableFont_wght.ttf in Resources */,
 				8A51624A2AC404E600EEB1B4 /* Pretendard-Bold.otf in Resources */,
 				8A5162462AC401EF00EEB1B4 /* Pretendard-Regular.otf in Resources */,
 				8A51624D2AC41D7100EEB1B4 /* Localizable.strings in Resources */,
 				8A1D0C542AC3FD0600C7FCF8 /* Pretendard-Thin.otf in Resources */,
-				D167A0742AF6192400B70E5E /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/gridy/Sources/ContentView.swift
+++ b/gridy/Sources/ContentView.swift
@@ -10,12 +10,10 @@ import ComposableArchitecture
 
 struct ContentView: View {
     let windowManager: WindowManager
-
     let store = Store(initialState: Authentication.State()) {
         Authentication()
             ._printChanges()
     }
-    
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             ZStack {
@@ -23,7 +21,7 @@ struct ContentView: View {
                     ZStack {
                         SplashView()
                         AuthenticationView(store: store)
-                    
+                        
                     }
                 } else {
                     ProjectBoardView(
@@ -39,8 +37,9 @@ struct ContentView: View {
     }
 }
 
-//struct ContentView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        ContentView()
-//    }
-//}
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        let windowManager = WindowManager()
+        ContentView(windowManager: windowManager)
+    }
+}

--- a/gridy/Sources/ContentView.swift
+++ b/gridy/Sources/ContentView.swift
@@ -21,7 +21,6 @@ struct ContentView: View {
                     ZStack {
                         SplashView()
                         AuthenticationView(store: store)
-                        
                     }
                 } else {
                     ProjectBoardView(

--- a/gridy/Sources/ContentView.swift
+++ b/gridy/Sources/ContentView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 import ComposableArchitecture
 
 struct ContentView: View {
-    
+    let windowManager: WindowManager
+
     let store = Store(initialState: Authentication.State()) {
         Authentication()
             ._printChanges()
@@ -22,13 +23,15 @@ struct ContentView: View {
                     ZStack {
                         SplashView()
                         AuthenticationView(store: store)
+                    
                     }
                 } else {
                     ProjectBoardView(
                         store: store.scope(
                             state: \.optionalProjectBoard,
                             action: { .optionalProjectBoard($0) }
-                        )
+                        ),
+                        windowManager: windowManager
                     )
                 }
             }
@@ -36,8 +39,8 @@ struct ContentView: View {
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
-}
+//struct ContentView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ContentView()
+//    }
+//}

--- a/gridy/Sources/Presentations/Common/TabBarView.swift
+++ b/gridy/Sources/Presentations/Common/TabBarView.swift
@@ -28,7 +28,6 @@ struct TabBarView: View {
             HStack(alignment: .center, spacing: 0) {
                 if !isMaximized {
                     Spacer().frame(width: 75)
-                    
                 }
                 systemBorder(.vertical)
                 homeButton

--- a/gridy/Sources/Presentations/Common/TabBarView.swift
+++ b/gridy/Sources/Presentations/Common/TabBarView.swift
@@ -10,6 +10,7 @@ import ComposableArchitecture
 
 struct TabBarView: View {
     let store: StoreOf<ProjectBoard>
+    let isMaximized: Bool
     
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
@@ -25,7 +26,10 @@ struct TabBarView: View {
                 )
             }
             HStack(alignment: .center, spacing: 0) {
-                windowControlsButton
+                if !isMaximized {
+                    Spacer().frame(width: 75)
+                    
+                }
                 systemBorder(.vertical)
                 homeButton
                 systemBorder(.vertical)
@@ -48,23 +52,6 @@ struct TabBarView: View {
             }
             .background(Color.tabBar)
         }
-    }
-}
-
-extension TabBarView {
-    var windowControlsButton: some View {
-        HStack(alignment: .top, spacing: 8) {
-            Circle()
-                .foregroundStyle(.red)
-                .frame(width: 12, height: 12)
-            Circle()
-                .foregroundStyle(.yellow)
-                .frame(width: 12, height: 12)
-            Circle()
-                .foregroundStyle(.green)
-                .frame(width: 12, height: 12)
-        }
-        .padding(.horizontal, 12)
     }
 }
 
@@ -183,6 +170,7 @@ struct TabItemView: View {
                         viewStore.send(.deleteShowingTab(projectID: projectID))
                     }
             }
+            
             .background(
                 viewStore.hoveredItem == projectID ||
                 viewStore.hoveredItem == .tabItemDeleteButton + projectID ||

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 struct ProjectBoardView: View {
     let store: StoreOf<ProjectBoard>
     let windowManager: WindowManager
-
+    
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             var isUserSettingPresented: Binding<Bool> {
@@ -79,10 +79,16 @@ struct ProjectBoardView: View {
                         listArea
                     }
                 } else {
-                    PlanBoardView(store: store.scope(
-                        state: \.planBoards[id: currentShowingPlanBoardID]!,
-                        action: { .planBoardAction(id: currentShowingPlanBoardID, action: $0) }
-                    ))
+                    IfLetStore(
+                        store.scope(
+                            state: \.planBoards[id: currentShowingPlanBoardID],
+                            action: { .planBoardAction(id: currentShowingPlanBoardID, action: $0) }
+                        )
+                    ) {
+                        PlanBoardView(store: $0)
+                    } else: {
+                        ProgressView()
+                    }
                 }
             }
             .onAppear {

--- a/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
+++ b/gridy/Sources/Presentations/ProjectBoard/ProjectBoardView.swift
@@ -10,7 +10,8 @@ import ComposableArchitecture
 
 struct ProjectBoardView: View {
     let store: StoreOf<ProjectBoard>
-    
+    let windowManager: WindowManager
+
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             var isUserSettingPresented: Binding<Bool> {
@@ -39,7 +40,8 @@ struct ProjectBoardView: View {
                 viewStore.showingProject!.id
             }
             VStack(alignment: .leading, spacing: 0) {
-                TabBarView(store: store)
+                
+                TabBarView(store: store, isMaximized: windowManager.isMaximized)
                     .frame(height: 36)
                     .zIndex(2)
                 if viewStore.tabBarFocusGroupClickedItem == .homeButton {
@@ -77,16 +79,10 @@ struct ProjectBoardView: View {
                         listArea
                     }
                 } else {
-                    IfLetStore(
-                        store.scope(
-                            state: \.planBoards[id: currentShowingPlanBoardID],
-                            action: { .planBoardAction(id: currentShowingPlanBoardID, action: $0) }
-                        )
-                    ) {
-                        PlanBoardView(store: $0)
-                    } else: {
-                        ProgressView()
-                    }
+                    PlanBoardView(store: store.scope(
+                        state: \.planBoards[id: currentShowingPlanBoardID]!,
+                        action: { .planBoardAction(id: currentShowingPlanBoardID, action: $0) }
+                    ))
                 }
             }
             .onAppear {

--- a/gridy/Sources/gridyApp.swift
+++ b/gridy/Sources/gridyApp.swift
@@ -24,7 +24,6 @@ struct GridyApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
-    @Published var isMaximized = false
     var windowManager = WindowManager()
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         FirebaseApp.configure()

--- a/gridy/Sources/gridyApp.swift
+++ b/gridy/Sources/gridyApp.swift
@@ -12,18 +12,49 @@ import ComposableArchitecture
 @main
 struct GridyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
-
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                ContentView()
+                ContentView(windowManager: delegate.windowManager)
+                    .ignoresSafeArea(.all, edges: .all)
             }
         }
+        .windowStyle(HiddenTitleBarWindowStyle())
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    @Published var isMaximized = false
+    var windowManager = WindowManager()
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         FirebaseApp.configure()
+        for window in NSApplication.shared.windows {
+            updateMaximizedStatus(window: window)
+            let customToolbar = NSToolbar()
+            window.toolbar = customToolbar
+            window.delegate = self
+        }
     }
+    func windowDidResize(_ notification: Notification) {
+        if let window = notification.object as? NSWindow {
+            updateMaximizedStatus(window: window)
+            DispatchQueue.main.async {
+                if self.windowManager.isMaximized {
+                    window.toolbar = nil
+                } else {
+                    let customToolbar = NSToolbar()
+                    window.toolbar = customToolbar
+                }
+            }
+        }
+    }
+    private func updateMaximizedStatus(window: NSWindow) {
+        let screenSize = window.screen?.visibleFrame.size ?? NSSize.zero
+        let windowSize = window.frame.size
+        windowManager.isMaximized = (windowSize.width >= screenSize.width && windowSize.height >= screenSize.height)
+    }
+}
+
+class WindowManager: ObservableObject {
+    @Published var isMaximized = false
 }


### PR DESCRIPTION
# Description
close #86 
- Window Button을 원래 커스텀해서 만들다가 원래의 Window Button과 TabBarView를 함께 써야 하는 것을 깨달아서 함께 나오게 하였습니다.
- ToolBar를 만들어서 Window Button의 위치를 맞추었고, 최대화를 할 경우 ToolBar를 없애서 TabBarView만 맨 위에 나오게 하였습니다.
- 최대화의 경우 windowSize를 계산해서 최대화가 되었을때 ToolBar를 없앴습니다. 그러고 다시 최대화를 해제하는 경우 ToolBar를 만들었습니다.
- 또한, 최대화를 하였을때 Window Button이 없어질 경우 그 공간이 없어지기에 최대화가 되지 않았을 경우에만 Spacer를 넣어서 Window Button과 맞추어주었습니다.

# Screenshots & Demo
처음 창을 띄웠을때는 Window Button과 TabBarView과 함께 있습니다. (ToolBar를 만들어서)
<img width="990" alt="스크린샷 2023-11-22 오전 12 41 42" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-Ampersand/assets/61958748/e2919dd8-f12e-47a4-a5fd-f3c206532a8a">
<br>
최대화를 할 경우에는 Window Button이 없어지고 원래의 탭들이 앞으로 옵니다. (ToolBar를 다시 nil로 만들어서 없앱니다.)
<img width="2559" alt="스크린샷 2023-11-22 오전 12 42 14" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-Ampersand/assets/61958748/c02c47d4-27bd-4430-b95d-8b8c8267f67b">
<br>
다시 최대화를 해제할 경우에는 처음처럼 다시 돌아옵니다. (ToolBar를 다시 만듭니다.)
<img width="990" alt="스크린샷 2023-11-22 오전 12 41 42" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team15-Ampersand/assets/61958748/a96bf913-e877-47c0-bab5-e79c33b1848b">


# To Reviewers 🤲
전체적으로 최대화 최소화 부분을 작업해서 GridyApp과 ContentView를 많이 건들게 되었는데 괜찮을까요..?